### PR TITLE
Provide a hint about how to install the OpenSlide dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,7 @@ Requirements
 Installation
 ============
 
-1.  `Install OpenSlide`_.
-
+1.  `Install OpenSlide`_.  (On Windows, donwload the provided prebuilt binaries, extract the ZIP file, and include the full path to the bin folder in the system path.)
 2.  ``pip install openslide-python``
 
 .. _`Install OpenSlide`: https://openslide.org/download/


### PR DESCRIPTION
This is not documented on the OpenSlide site, that I could see, so for Python users, a hint could be helpful.