### PR TITLE
Fix ImportError in Python 3.9

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -99,7 +99,7 @@ OpenSlide objects
    .. attribute:: properties
 
       Metadata about the slide, in the form of a
-      :class:`Mapping <collections.Mapping>` from OpenSlide property name to
+      :class:`Mapping <collections.abc.Mapping>` from OpenSlide property name to
       property value.  Property values are always strings.  OpenSlide
       provides some :ref:`standard properties <Standard properties>`, plus
       additional properties that vary by slide format.
@@ -107,7 +107,7 @@ OpenSlide objects
    .. attribute:: associated_images
 
       Images, such as label or macro images, which are associated with this
-      slide.  This is a :class:`Mapping <collections.Mapping>` from image
+      slide.  This is a :class:`Mapping <collections.abc.Mapping>` from image
       name to RGBA :class:`Image <PIL.Image.Image>`.
 
       Unlike in the C interface, these images are not premultiplied.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -107,7 +107,7 @@ OpenSlide objects
    .. attribute:: associated_images
 
       Images, such as label or macro images, which are associated with this
-      slide.  This is a :class:`Mapping <collections.abc.Mapping>` from image
+      slide.  This is a :class:`~collections.abc.Mapping` from image
       name to RGBA :class:`Image <PIL.Image.Image>`.
 
       Unlike in the C interface, these images are not premultiplied.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -99,7 +99,7 @@ OpenSlide objects
    .. attribute:: properties
 
       Metadata about the slide, in the form of a
-      :class:`Mapping <collections.abc.Mapping>` from OpenSlide property name to
+      :class:`~collections.abc.Mapping` from OpenSlide property name to
       property value.  Property values are always strings.  OpenSlide
       provides some :ref:`standard properties <Standard properties>`, plus
       additional properties that vary by slide format.

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -23,8 +23,14 @@ This package provides Python bindings for the OpenSlide library.
 """
 
 from __future__ import division, print_function
-from collections import Mapping
 from PIL import Image
+
+try:
+    # Python 3.3+
+    from collections.abc import Mapping
+except ImportError:
+    # Python 2
+    from collections import Mapping
 
 from openslide import lowlevel
 


### PR DESCRIPTION
```console
$ cat 1.py
from collections import Mapping

```

```console
$ python --version
Python 3.8.0
$ python 1.py
1.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  from collections import Mapping
```

```console
$ python --version
Python 3.9.0a2+
$ python 1.py
Traceback (most recent call last):
  File "/private/tmp/openslide-python/1.py", line 1, in <module>
    from collections import Mapping
ImportError: cannot import name 'Mapping' from 'collections' (/Users/hugo/.pyenv/versions/3.9-dev/lib/python3.9/collections/__init__.py)
```

Also reported at https://bugzilla.redhat.com/show_bug.cgi?id=1791684.