### PR TITLE
Remove "Feature" which has been discontinued from setuptools=46

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from setuptools import setup, Extension, Feature
+from setuptools import setup, Extension
 
 # Load version string
 _verfile = os.path.join(os.path.dirname(__file__), 'openslide', '_version.py')
@@ -15,15 +15,6 @@ setup(
     packages=[
         'openslide',
     ],
-    features={
-        'performance': Feature(
-            'performance-enhancing extension module',
-            standard=True,
-            ext_modules=[
-                Extension('openslide._convert', ['openslide/_convert.c']),
-            ],
-        ),
-    },
     test_suite='tests',
     maintainer='OpenSlide project',
     maintainer_email='openslide-users@lists.andrew.cmu.edu',


### PR DESCRIPTION
Setuptools 46 has discontinued the use of `Feature` and hence this fails to build against the version.
This PR removes it so it remains compatible 