### PR TITLE
Fix failure to find libopenslide-0.dll on Windows

### DIFF
--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -40,7 +40,7 @@ import sys
 from . import _convert
 
 if platform.system() == 'Windows':
-    _lib = cdll.LoadLibrary('libopenslide-0.dll')
+    from ctypes.util import find_library;_lib = cdll.LoadLibrary(find_library('libopenslide-0.dll'))
 elif platform.system() == 'Darwin':
     try:
         _lib = cdll.LoadLibrary('libopenslide.0.dylib')


### PR DESCRIPTION
In issue #51 I suggested doing this; it was mentioned in issue #23 as well. On every machine, on which I tried installing the library, I had to edit this line.