### PR TITLE
Drop support for Python 2 and PIL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,9 +40,9 @@ OpenSlide can read virtual slides in several formats:
 Requirements
 ============
 
-* Python 2 >= 2.6 or Python 3 >= 3.3
+* Python 3 >= 3.3
 * OpenSlide >= 3.4.0
-* Python Imaging Library or Pillow
+* Pillow
 
 
 Installation
@@ -53,24 +53,6 @@ Installation
 2.  ``pip install openslide-python``
 
 .. _`Install OpenSlide`: https://openslide.org/download/
-
-
-Using PIL
----------
-
-``setup.py`` assumes that you want to use the Pillow fork of PIL.  If you
-already have classic PIL installed, you can use it instead.  Install
-OpenSlide Python with:
-
-::
-
-  pip install --no-deps openslide-python
-
-or, if you are installing by hand:
-
-::
-
-  python setup.py install --single-version-externally-managed --record /dev/null
 
 
 More Information

--- a/examples/deepzoom/deepzoom_multiserver.py
+++ b/examples/deepzoom/deepzoom_multiserver.py
@@ -41,12 +41,6 @@ app.config.from_object(__name__)
 app.config.from_envvar('DEEPZOOM_MULTISERVER_SETTINGS', silent=True)
 
 
-class PILBytesIO(BytesIO):
-    def fileno(self):
-        '''Classic PIL doesn't understand io.UnsupportedOperation.'''
-        raise AttributeError('Not supported')
-
-
 class _SlideCache(object):
     def __init__(self, cache_size, dz_opts):
         self.cache_size = cache_size
@@ -161,7 +155,7 @@ def tile(path, level, col, row, format):
     except ValueError:
         # Invalid level or coordinates
         abort(404)
-    buf = PILBytesIO()
+    buf = BytesIO()
     tile.save(buf, format, quality=app.config['DEEPZOOM_TILE_QUALITY'])
     resp = make_response(buf.getvalue())
     resp.mimetype = 'image/%s' % format

--- a/examples/deepzoom/deepzoom_server.py
+++ b/examples/deepzoom/deepzoom_server.py
@@ -40,12 +40,6 @@ app.config.from_object(__name__)
 app.config.from_envvar('DEEPZOOM_TILER_SETTINGS', silent=True)
 
 
-class PILBytesIO(BytesIO):
-    def fileno(self):
-        '''Classic PIL doesn't understand io.UnsupportedOperation.'''
-        raise AttributeError('Not supported')
-
-
 @app.before_first_request
 def load_slide():
     slidefile = app.config['DEEPZOOM_SLIDE']
@@ -111,7 +105,7 @@ def tile(slug, level, col, row, format):
     except ValueError:
         # Invalid level or coordinates
         abort(404)
-    buf = PILBytesIO()
+    buf = BytesIO()
     tile.save(buf, format, quality=app.config['DEEPZOOM_TILE_QUALITY'])
     resp = make_response(buf.getvalue())
     resp.mimetype = 'image/%s' % format

--- a/examples/deepzoom/deepzoom_tile.py
+++ b/examples/deepzoom/deepzoom_tile.py
@@ -20,7 +20,6 @@
 
 """An example program to generate a Deep Zoom directory tree from a slide."""
 
-from __future__ import print_function
 import json
 from multiprocessing import Process, JoinableQueue
 import openslide

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -33,17 +33,17 @@ from openslide._version import __version__
 
 __library_version__ = lowlevel.get_version()
 
-PROPERTY_NAME_COMMENT          = u'openslide.comment'
-PROPERTY_NAME_VENDOR           = u'openslide.vendor'
-PROPERTY_NAME_QUICKHASH1       = u'openslide.quickhash-1'
-PROPERTY_NAME_BACKGROUND_COLOR = u'openslide.background-color'
-PROPERTY_NAME_OBJECTIVE_POWER  = u'openslide.objective-power'
-PROPERTY_NAME_MPP_X            = u'openslide.mpp-x'
-PROPERTY_NAME_MPP_Y            = u'openslide.mpp-y'
-PROPERTY_NAME_BOUNDS_X         = u'openslide.bounds-x'
-PROPERTY_NAME_BOUNDS_Y         = u'openslide.bounds-y'
-PROPERTY_NAME_BOUNDS_WIDTH     = u'openslide.bounds-width'
-PROPERTY_NAME_BOUNDS_HEIGHT    = u'openslide.bounds-height'
+PROPERTY_NAME_COMMENT          = 'openslide.comment'
+PROPERTY_NAME_VENDOR           = 'openslide.vendor'
+PROPERTY_NAME_QUICKHASH1       = 'openslide.quickhash-1'
+PROPERTY_NAME_BACKGROUND_COLOR = 'openslide.background-color'
+PROPERTY_NAME_OBJECTIVE_POWER  = 'openslide.objective-power'
+PROPERTY_NAME_MPP_X            = 'openslide.mpp-x'
+PROPERTY_NAME_MPP_Y            = 'openslide.mpp-y'
+PROPERTY_NAME_BOUNDS_X         = 'openslide.bounds-x'
+PROPERTY_NAME_BOUNDS_Y         = 'openslide.bounds-y'
+PROPERTY_NAME_BOUNDS_WIDTH     = 'openslide.bounds-width'
+PROPERTY_NAME_BOUNDS_HEIGHT    = 'openslide.bounds-height'
 
 class AbstractSlide(object):
     """The base class of a slide object."""

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -22,15 +22,8 @@
 This package provides Python bindings for the OpenSlide library.
 """
 
-from __future__ import division, print_function
+from collections.abc import Mapping
 from PIL import Image
-
-try:
-    # Python 3.3+
-    from collections.abc import Mapping
-except ImportError:
-    # Python 2
-    from collections import Mapping
 
 from openslide import lowlevel
 

--- a/openslide/_convert.c
+++ b/openslide/_convert.c
@@ -95,7 +95,6 @@ static PyMethodDef ConvertMethods[] = {
     {NULL, NULL, 0, NULL}
 };
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef convertmodule = {
     PyModuleDef_HEAD_INIT,
     "_convert",
@@ -109,10 +108,3 @@ PyInit__convert(void)
 {
     return PyModule_Create(&convertmodule);
 }
-#else
-PyMODINIT_FUNC
-init_convert(void)
-{
-    Py_InitModule("_convert", ConvertMethods);
-}
-#endif

--- a/openslide/_version.py
+++ b/openslide/_version.py
@@ -22,4 +22,4 @@
 This module is an implementation detail.  The package version should be
 obtained from openslide.__version__."""
 
-__version__ = u'1.1.2'
+__version__ = '1.1.2'

--- a/openslide/deepzoom.py
+++ b/openslide/deepzoom.py
@@ -23,7 +23,6 @@ This module provides functionality for generating Deep Zoom images from
 OpenSlide objects.
 """
 
-from __future__ import division
 from io import BytesIO
 import math
 import openslide

--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -30,12 +30,10 @@ returned by OpenSlide into a non-premultiplied PIL.Image happens here
 rather than in the high-level interface.)
 """
 
-from __future__ import division
 from ctypes import *
 from itertools import count
 import PIL.Image
 import platform
-import sys
 
 from . import _convert
 
@@ -100,18 +98,11 @@ class _OpenSlide(object):
 class _utf8_p(object):
     """Wrapper class to convert string arguments to bytes."""
 
-    if sys.version[0] == '2':
-        _bytes_type = str
-        _str_type = unicode
-    else:
-        _bytes_type = bytes
-        _str_type = str
-
     @classmethod
     def from_param(cls, obj):
-        if isinstance(obj, cls._bytes_type):
+        if isinstance(obj, bytes):
             return obj
-        elif isinstance(obj, cls._str_type):
+        elif isinstance(obj, str):
             return obj.encode('UTF-8')
         else:
             raise TypeError('Incorrect type')

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,6 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
@@ -49,7 +46,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
     ],
-    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
+    python_requires='>=3.3',
     install_requires=[
         'Pillow',
     ],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -33,19 +33,3 @@ except ValueError:
 
 def file_path(name):
     return os.path.join(os.path.dirname(__file__), name)
-
-
-def skip_if(condition, reason):
-    if hasattr(unittest, 'skipIf'):
-        # Python >= 2.7
-        return unittest.skipIf(condition, reason)
-    else:
-        # Python 2.6
-        def decorator(f):
-            @wraps(f)
-            def wrapper(*args, **kwargs):
-                if condition:
-                    return
-                return f(*args, **kwargs)
-            return wrapper
-        return decorator

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -19,19 +19,11 @@
 
 import openslide
 from openslide import open_slide, OpenSlide, ImageSlide
-import sys
 import unittest
 
 from . import file_path
 
-# Tests should be written to be compatible with Python 2.6 unittest.
-
 class TestLibrary(unittest.TestCase):
-    def test_version(self):
-        string = unicode if sys.version[0] == '2' else str
-        self.assertTrue(isinstance(openslide.__version__, string))
-        self.assertTrue(isinstance(openslide.__library_version__, string))
-
     def test_open_slide(self):
         with open_slide(file_path('boxes.tiff')) as osr:
             self.assertTrue(isinstance(osr, OpenSlide))

--- a/tests/test_deepzoom.py
+++ b/tests/test_deepzoom.py
@@ -23,8 +23,6 @@ import unittest
 
 from . import file_path
 
-# Tests should be written to be compatible with Python 2.6 unittest.
-
 class _BoxesDeepZoomTest(object):
     def setUp(self):
         self.osr = self.CLASS(file_path(self.FILENAME))

--- a/tests/test_imageslide.py
+++ b/tests/test_imageslide.py
@@ -22,9 +22,7 @@ from openslide import ImageSlide, OpenSlideError
 from PIL import Image
 import unittest
 
-from . import file_path, image_dimensions_cannot_be_zero, skip_if
-
-# Tests should be written to be compatible with Python 2.6 unittest.
+from . import file_path, image_dimensions_cannot_be_zero
 
 @contextmanager
 def image_open(*args, **kwargs):
@@ -104,7 +102,7 @@ class TestImage(unittest.TestCase):
         self.assertEqual(self.osr.read_region((-10, -10), 0, (400, 400)).size,
                 (400, 400))
 
-    @skip_if(image_dimensions_cannot_be_zero, 'Pillow issue #2259')
+    @unittest.skipIf(image_dimensions_cannot_be_zero, 'Pillow issue #2259')
     def test_read_region_size_dimension_zero(self):
         self.assertEqual(self.osr.read_region((0, 0), 0, (400, 0)).size,
                 (400, 0))

--- a/tests/test_openslide.py
+++ b/tests/test_openslide.py
@@ -25,9 +25,7 @@ import re
 import sys
 import unittest
 
-from . import file_path, image_dimensions_cannot_be_zero, skip_if
-
-# Tests should be written to be compatible with Python 2.6 unittest.
+from . import file_path, image_dimensions_cannot_be_zero
 
 class TestSlideWithoutOpening(unittest.TestCase):
     def test_detect_format(self):
@@ -110,7 +108,7 @@ class TestSlide(_SlideTest, unittest.TestCase):
         self.assertEqual(self.osr.read_region((-10, -10), 1, (400, 400)).size,
                 (400, 400))
 
-    @skip_if(image_dimensions_cannot_be_zero, 'Pillow issue #2259')
+    @unittest.skipIf(image_dimensions_cannot_be_zero, 'Pillow issue #2259')
     def test_read_region_size_dimension_zero(self):
         self.assertEqual(self.osr.read_region((0, 0), 1, (400, 0)).size,
                 (400, 0))
@@ -123,11 +121,11 @@ class TestSlide(_SlideTest, unittest.TestCase):
         self.assertRaises(OpenSlideError,
                 lambda: self.osr.read_region((0, 0), 1, (400, -5)))
 
-    @skip_if(sys.maxsize < 1 << 32, '32-bit Python')
-    # Broken on PIL and on Pillow >= 3.4.0, < 6.2.0.
+    @unittest.skipIf(sys.maxsize < 1 << 32, '32-bit Python')
+    # Broken on Pillow >= 3.4.0, < 6.2.0.
     # https://github.com/python-pillow/Pillow/issues/3963
-    @skip_if([int(i) for i in getattr(Image, '__version__', '0').split('.')] < [6,2,0],
-            'broken on PIL and Pillow < 6.2.0')
+    @unittest.skipIf([int(i) for i in getattr(Image, '__version__', '0').split('.')] < [6,2,0],
+            'broken on Pillow < 6.2.0')
     # Disabled to avoid OOM killer on small systems, since the stdlib
     # doesn't provide a way to find out how much RAM we have
     def _test_read_region_2GB(self):


### PR DESCRIPTION
Python 2 reached EOL more than a year ago, taking PIL with it.

Closes #93.