### PR TITLE
Add support for pathlib.Path instances

### DIFF
--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -149,7 +149,9 @@ class OpenSlide(AbstractSlide):
     def __init__(self, filename):
         """Open a whole-slide image."""
         AbstractSlide.__init__(self)
-        self._filename = filename
+        # Filename might be a pathlib.Path instance, but file reader expects
+        # a string.
+        self._filename = str(filename)
         self._osr = lowlevel.open(filename)
 
     def __repr__(self):

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -149,10 +149,8 @@ class OpenSlide(AbstractSlide):
     def __init__(self, filename):
         """Open a whole-slide image."""
         AbstractSlide.__init__(self)
-        # Filename might be a pathlib.Path instance, but file reader expects
-        # a string.
-        self._filename = str(filename)
-        self._osr = lowlevel.open(filename)
+        self._filename = filename
+        self._osr = lowlevel.open(str(filename))
 
     def __repr__(self):
         return '%s(%r)' % (self.__class__.__name__, self._filename)
@@ -162,7 +160,7 @@ class OpenSlide(AbstractSlide):
         """Return a string describing the format vendor of the specified file.
 
         If the file format is not recognized, return None."""
-        return lowlevel.detect_vendor(filename)
+        return lowlevel.detect_vendor(str(filename))
 
     def close(self):
         """Close the OpenSlide object."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,6 +19,8 @@
 
 from functools import wraps
 import os
+from pathlib import Path
+
 from PIL import Image
 import unittest
 
@@ -52,4 +54,4 @@ except ValueError:
 
 
 def file_path(name):
-    return os.path.join(os.path.dirname(__file__), name)
+    return Path(__file__).parent / name


### PR DESCRIPTION
`pathlib.Path` instances are commonly used, but the `openslide.OpenSlide` class was not compatible with the `pathlib.Path` type. This commit converts the `slide._filename` attribute to a `str` type in `__init__`. This means that the `openslide.OpenSlide` class can now accept a `pathlib.Path` instance.