### PR TITLE
Support OpenSlide cache management API

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -220,6 +220,11 @@ Exceptions
    OpenSlide does not support the requested file.  Subclass of
    :exc:`OpenSlideError`.
 
+.. exception:: OpenSlideVersionError
+
+   This version of OpenSlide does not support the requested functionality.
+   Subclass of :exc:`OpenSlideError`.
+
 
 Wrapping a PIL Image
 ====================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -138,9 +138,33 @@ OpenSlide objects
       :param tuple size: the maximum size of the thumbnail as a
          ``(width, height)`` tuple
 
+   .. method:: set_cache(cache)
+
+      Use the specified :class:`OpenSlideCache` to store recently decoded
+      slide tiles.  By default, the :class:`OpenSlide` has a private cache
+      with a default size.
+
+      :param OpenSlideCache cache: a cache object
+      :raises OpenSlideVersionError: if OpenSlide is older than version 3.5.0
+
    .. method:: close()
 
       Close the OpenSlide object.
+
+
+Caching
+-------
+
+.. class:: OpenSlideCache(capacity)
+
+   An in-memory tile cache.
+
+   Tile caches can be attached to one or more :class:`OpenSlide` objects
+   with :meth:`OpenSlide.set_cache` to cache recently-decoded tiles.  By
+   default, each :class:`OpenSlide` has its own cache with a default size.
+
+   :param int capacity: the cache capacity in bytes
+   :raises OpenSlideVersionError: if OpenSlide is older than version 3.5.0
 
 
 .. _standard-properties:

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -30,7 +30,11 @@ from openslide import lowlevel
 
 # For the benefit of library users
 from openslide._version import __version__  # noqa: F401  module-imported-but-unused
-from openslide.lowlevel import OpenSlideError, OpenSlideUnsupportedFormatError
+from openslide.lowlevel import (  # noqa: F401  module-imported-but-unused
+    OpenSlideError,
+    OpenSlideUnsupportedFormatError,
+    OpenSlideVersionError,
+)
 
 __library_version__ = lowlevel.get_version()
 

--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -2,7 +2,7 @@
 # openslide-python - Python bindings for the OpenSlide library
 #
 # Copyright (c) 2010-2013 Carnegie Mellon University
-# Copyright (c) 2016 Benjamin Gilbert
+# Copyright (c) 2016-2021 Benjamin Gilbert
 #
 # This library is free software; you can redistribute it and/or modify it
 # under the terms of version 2.1 of the GNU Lesser General Public License
@@ -186,8 +186,18 @@ def _check_name_list(result, func, args):
 
 
 # resolve and return an OpenSlide function with the specified properties
-def _func(name, restype, argtypes, errcheck=_check_error):
-    func = getattr(_lib, name)
+def _func(name, restype, argtypes, errcheck=_check_error, minimum_version=None):
+    try:
+        func = getattr(_lib, name)
+    except AttributeError:
+        if minimum_version is None:
+            raise
+
+        # optional function doesn't exist; fail at runtime
+        def function_unavailable(*_args):
+            raise OpenSlideVersionError(minimum_version)
+
+        return function_unavailable
     func.argtypes = argtypes
     func.restype = restype
     if errcheck is not None:

--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -76,6 +76,17 @@ class OpenSlideError(Exception):
     """
 
 
+class OpenSlideVersionError(OpenSlideError):
+    """This version of OpenSlide does not support the requested functionality.
+
+    Import this from openslide rather than from openslide.lowlevel.
+    """
+
+    def __init__(self, minimum_version):
+        super().__init__(f'OpenSlide >= {minimum_version} required')
+        self.minimum_version = minimum_version
+
+
 class OpenSlideUnsupportedFormatError(OpenSlideError):
     """OpenSlide does not support the requested file.
 
@@ -187,7 +198,7 @@ def _func(name, restype, argtypes, errcheck=_check_error):
 try:
     detect_vendor = _func('openslide_detect_vendor', c_char_p, [_utf8_p], _check_string)
 except AttributeError:
-    raise OpenSlideError('OpenSlide >= 3.4.0 required')
+    raise OpenSlideVersionError('3.4.0')
 
 open = _func('openslide_open', c_void_p, [_utf8_p], _check_open)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 #
 # openslide-python - Python bindings for the OpenSlide library
 #
-# Copyright (c) 2016 Benjamin Gilbert
+# Copyright (c) 2016-2021 Benjamin Gilbert
 #
 # This library is free software; you can redistribute it and/or modify it
 # under the terms of version 2.1 of the GNU Lesser General Public License
@@ -17,6 +17,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from functools import wraps
 import os
 from pathlib import Path
 
@@ -42,6 +43,7 @@ if os.name == 'nt':
 
             os.environ['PATH'] = _orig_path
 
+from openslide import OpenSlideVersionError
 
 # PIL.Image cannot have zero width or height on Pillow 3.4.0 - 3.4.2
 # https://github.com/python-pillow/Pillow/issues/2259
@@ -54,3 +56,17 @@ except ValueError:
 
 def file_path(name):
     return Path(__file__).parent / name
+
+
+def maybe_supported(f):
+    '''Decorator to ignore test failures caused by an OpenSlide version that
+    doesn't support the tested functionality.'''
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except OpenSlideVersionError:
+            pass
+
+    return wrapper

--- a/tests/test_imageslide.py
+++ b/tests/test_imageslide.py
@@ -1,7 +1,7 @@
 #
 # openslide-python - Python bindings for the OpenSlide library
 #
-# Copyright (c) 2016 Benjamin Gilbert
+# Copyright (c) 2016-2021 Benjamin Gilbert
 #
 # This library is free software; you can redistribute it and/or modify it
 # under the terms of version 2.1 of the GNU Lesser General Public License
@@ -22,9 +22,9 @@ import unittest
 
 from PIL import Image
 
-from openslide import ImageSlide, OpenSlideError
+from openslide import ImageSlide, OpenSlideCache, OpenSlideError
 
-from . import file_path, image_dimensions_cannot_be_zero
+from . import file_path, image_dimensions_cannot_be_zero, maybe_supported
 
 
 @contextmanager
@@ -118,3 +118,8 @@ class TestImage(unittest.TestCase):
 
     def test_thumbnail(self):
         self.assertEqual(self.osr.get_thumbnail((100, 100)).size, (100, 83))
+
+    @maybe_supported
+    def test_set_cache(self):
+        self.osr.set_cache(OpenSlideCache(64 << 10))
+        self.assertEqual(self.osr.read_region((0, 0), 0, (400, 400)).size, (400, 400))

--- a/tests/test_openslide.py
+++ b/tests/test_openslide.py
@@ -59,7 +59,11 @@ class TestSlideWithoutOpening(unittest.TestCase):
         self.assertRaises(
             OpenSlideUnsupportedFormatError, lambda: OpenSlide('setup.py')
         )
-        self.assertRaises(OpenSlideError, lambda: OpenSlide('unopenable.tiff'))
+        self.assertRaises(OpenSlideUnsupportedFormatError, lambda: OpenSlide(None))
+        self.assertRaises(OpenSlideUnsupportedFormatError, lambda: OpenSlide(3))
+        self.assertRaises(
+            OpenSlideUnsupportedFormatError, lambda: OpenSlide('unopenable.tiff')
+        )
 
     def test_operations_on_closed_handle(self):
         osr = OpenSlide(file_path('boxes.tiff'))


### PR DESCRIPTION
Support the cache management API implemented in https://github.com/openslide/openslide/pull/335.  Sample usage:

```python
import openslide
osr = openslide.OpenSlide("slide.svs")
cache = openslide.OpenSlideCache(256 << 20)
osr.set_cache(cache)
```