### PR TITLE
Use find_library to load libopenslide-0.dll for Windows

### DIFF
--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -49,7 +49,8 @@ import PIL.Image
 from . import _convert
 
 if platform.system() == 'Windows':
-    _lib = cdll.LoadLibrary('libopenslide-0.dll')
+    import ctypes.util
+    _lib = cdll.LoadLibrary(ctypes.util.find_library('libopenslide-0.dll'))
 elif platform.system() == 'Darwin':
     try:
         _lib = cdll.LoadLibrary('libopenslide.0.dylib')


### PR DESCRIPTION
Currently user has to copy libopenslide-0.dll into system folder.  If user has downloaded the openslide zip and added the openslide/bin to PATH, it fails to load `libopenslide-0.dll`.
Hence better to use find_library to find and load the dll file for windows as well.