### PR TITLE
Add installation instructions to docs; improve exceptions on library load failure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,11 +48,11 @@ Requirements
 Installation
 ============
 
-1.  `Install OpenSlide`_.
+OpenSlide Python requires OpenSlide_.  For instructions on installing both
+components so OpenSlide Python can find OpenSlide, see the package
+documentation_.
 
-2.  ``pip install openslide-python``
-
-.. _`Install OpenSlide`: https://openslide.org/download/
+.. _documentation: https://openslide.org/api/python/#installing
 
 
 More Information

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -41,6 +41,45 @@ Public License, version 2.1`_.
 .. _`GNU Lesser General Public License, version 2.1`: https://raw.github.com/openslide/openslide-python/main/lgpl-2.1.txt
 
 
+Installing
+==========
+
+OpenSlide Python requires OpenSlide_, which must be installed separately.
+
+On Linux and macOS, the easiest way to get both components is to install_
+with a package manager that packages both, such as Anaconda_, DNF or Apt on
+Linux systems, or MacPorts_ on macOS systems.  You can also install
+OpenSlide Python with pip_ after installing OpenSlide with a package manager
+or from source_.  Except for pip, do not mix OpenSlide and OpenSlide Python
+from different package managers (for example, OpenSlide from MacPorts and
+OpenSlide Python from Anaconda), since you'll get library conflicts.
+
+On Windows, download the OpenSlide `Windows binaries`_ and extract them
+to a known path.  Then, import ``openslide`` inside a
+``with os.add_dll_directory()`` statement::
+
+    # The path can also be read from a config file, etc.
+    OPENSLIDE_PATH = r'c:\path\to\openslide-win64\bin'
+
+    import os
+    if hasattr(os, 'add_dll_directory'):
+        # Python >= 3.8 on Windows
+        with os.add_dll_directory(OPENSLIDE_PATH):
+            import openslide
+    else:
+        import openslide
+
+This won't work with Python 3.7 or earlier; you'll need to add the OpenSlide
+``bin`` directory to your ``PATH`` instead.
+
+.. _install: https://openslide.org/download/#distribution-packages
+.. _Anaconda: https://anaconda.org/
+.. _MacPorts: https://www.macports.org/
+.. _pip: https://pip.pypa.io/en/stable/
+.. _source: https://openslide.org/download/#source
+.. _`Windows binaries`: https://openslide.org/download/#windows-binaries
+
+
 Basic usage
 ===========
 

--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -61,8 +61,9 @@ elif platform.system() == 'Darwin':
 
         _lib = ctypes.util.find_library('openslide')
         if _lib is None:
-            raise ImportError(
-                "Couldn't locate OpenSlide dylib.  Is OpenSlide installed?"
+            raise ModuleNotFoundError(
+                "Couldn't locate OpenSlide dylib.  Is OpenSlide installed "
+                "correctly?  https://openslide.org/api/python/#installing"
             )
         _lib = cdll.LoadLibrary(_lib)
 else:

--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -49,7 +49,20 @@ import PIL.Image
 from . import _convert
 
 if platform.system() == 'Windows':
-    _lib = cdll.LoadLibrary('libopenslide-0.dll')
+    try:
+        _lib = cdll.LoadLibrary('libopenslide-0.dll')
+    except FileNotFoundError:
+        import os
+
+        if hasattr(os, 'add_dll_directory'):
+            # Python >= 3.8
+            _admonition = 'Did you call os.add_dll_directory()?'
+        else:
+            _admonition = 'Did you add OpenSlide to PATH?'
+        raise ModuleNotFoundError(
+            f"Couldn't locate OpenSlide DLL.  {_admonition}  "
+            "https://openslide.org/api/python/#installing"
+        )
 elif platform.system() == 'Darwin':
     try:
         _lib = cdll.LoadLibrary('libopenslide.0.dylib')


### PR DESCRIPTION
Add installation instructions to the docs, hopefully addressing the recurring issues we've seen.  Explain that OpenSlide must be installed separately, point out that it can't be installed with a different full-service package manager than OpenSlide Python, and document the `os.add_dll_directory()` requirement for Python &ge; 3.8 on Windows.  Update the installation section of the README to point to the docs.

Also improve the exception when failing to load the dylib on macOS, and add a descriptive exception when failing to load the DLL on Windows.

Fixes https://github.com/openslide/openslide-python/issues/98.  Fixes https://github.com/openslide/openslide-python/issues/115.