### PR TITLE
examples/deepzoom: fix `./deepzoom_tile.py -r` with jinja2 3.x

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install Python tools
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
+        pip install jinja2 pytest
     - name: Install OpenSlide
       run: |
         case "${{ matrix.os }}" in
@@ -54,6 +54,8 @@ jobs:
       run: pip install -e .
     - name: Run tests
       run: pytest -v
+    - name: Tile slide
+      run: python examples/deepzoom/deepzoom_tile.py --viewer -o tiled tests/small.svs
   windows:
     name: Windows
     needs: pre-commit
@@ -112,6 +114,9 @@ jobs:
         python examples/deepzoom/deepzoom_multiserver.py -h >/dev/null
         python examples/deepzoom/deepzoom_server.py -h >/dev/null
         python examples/deepzoom/deepzoom_tile.py -h >/dev/null
+    - name: Tile slide
+      # Reads OPENSLIDE_PATH
+      run: python examples/deepzoom/deepzoom_tile.py --viewer -o tiled tests/small.svs
     - name: Archive wheel
       uses: actions/upload-artifact@v2
       with:

--- a/examples/deepzoom/deepzoom_tile.py
+++ b/examples/deepzoom/deepzoom_tile.py
@@ -214,7 +214,19 @@ class DeepZoomStaticTiler:
     def _write_html(self):
         import jinja2
 
-        env = jinja2.Environment(loader=jinja2.PackageLoader(__name__), autoescape=True)
+        # https://docs.python.org/3/reference/import.html#main-spec
+        if __spec__ is not None:
+            # We're running from a module (e.g. "python -m deepzoom_tile")
+            # so load templates from the containing package.
+            loader = jinja2.PackageLoader('__main__')
+        else:
+            # We're not running from a module (e.g. "python deepzoom_tile.py")
+            # so PackageLoader('__main__') doesn't work in jinja2 3.x.
+            # Load templates directly from the filesystem.
+            loader = jinja2.FileSystemLoader(
+                os.path.join(os.path.dirname(__file__), 'templates')
+            )
+        env = jinja2.Environment(loader=loader, autoescape=True)
         template = env.get_template('slide-multipane.html')
         associated_urls = {n: self._url_for(n) for n in self._slide.associated_images}
         try:


### PR DESCRIPTION
If our code was specified directly to Python (e.g. we're running as a command-line script), rather than running from a module, `PackageLoader` in jinja2 3.x fails to read our template with:

    ValueError: __main__.__spec__ is None

Read the template directly from the filesystem in this case.

Also add a simple `deepzoom_tile.py` CI test.