### PR TITLE
workflows: build wheels for all OS; python 3.11 support

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
     steps:
     - name: Check out repo
       uses: actions/checkout@v2
@@ -79,7 +79,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         python-arch: [x86, x64]
     steps:
     - name: Check out repo

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,7 +58,7 @@ jobs:
         mv dist/*.whl "artifacts/${basename}"
         echo "basename=${basename}" >> $GITHUB_ENV
     - name: Install
-      run: pip install -e .
+      run: pip install --find-links=${{github.workspace}} openslide_python
     - name: Run tests
       run: pytest -v
     - name: Tile slide
@@ -112,7 +112,7 @@ jobs:
         mv dist/*.whl "artifacts/${basename}"
         echo "basename=${basename}" >> $GITHUB_ENV
     - name: Install
-      run: pip install -e .
+      run: pip install --find-links=${{github.workspace}} openslide_python
     - name: Run tests
       # Reads OPENSLIDE_PATH
       run: pytest -v

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - name: Check out repo
       uses: actions/checkout@v2
@@ -79,7 +79,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         python-arch: [x86, x64]
     steps:
     - name: Check out repo

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,7 +58,7 @@ jobs:
         mv dist/*.whl "artifacts/${basename}"
         echo "basename=${basename}" >> $GITHUB_ENV
     - name: Install
-      run: pip install --find-links=${{github.workspace}} openslide_python
+      run: pip install -e .
     - name: Run tests
       run: pytest -v
     - name: Tile slide
@@ -112,7 +112,7 @@ jobs:
         mv dist/*.whl "artifacts/${basename}"
         echo "basename=${basename}" >> $GITHUB_ENV
     - name: Install
-      run: pip install --find-links=${{github.workspace}} openslide_python
+      run: pip install -e .
     - name: Run tests
       # Reads OPENSLIDE_PATH
       run: pytest -v

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,10 +2,10 @@ name: Python
 
 on:
   push:
-    branches: "*"
-    tags: "*"
+    branches: [main]
+    tags: ["*"]
   pull_request:
-    branches: "*"
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install Python tools
       run: |
         python -m pip install --upgrade pip
-        pip install jinja2 pytest
+        pip install jinja2 pytest wheel
     - name: Install OpenSlide
       run: |
         case "${{ matrix.os }}" in

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,10 +2,10 @@ name: Python
 
 on:
   push:
-    branches: [main]
-    tags: ["*"]
+    branches: "*"
+    tags: "*"
   pull_request:
-    branches: [main]
+    branches: "*"
 
 permissions:
   contents: read
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - name: Check out repo
       uses: actions/checkout@v2
@@ -50,12 +50,24 @@ jobs:
           brew install openslide
           ;;
         esac
+    - name: Build wheel
+      run: |
+        python setup.py bdist_wheel
+        basename=openslide-python-wheels-$GITHUB_RUN_NUMBER-$(echo $GITHUB_SHA | cut -c-10)
+        mkdir -p "artifacts/${basename}"
+        mv dist/*.whl "artifacts/${basename}"
+        echo "basename=${basename}" >> $GITHUB_ENV
     - name: Install
       run: pip install -e .
     - name: Run tests
       run: pytest -v
     - name: Tile slide
       run: python examples/deepzoom/deepzoom_tile.py --viewer -o tiled tests/small.svs
+    - name: Archive wheel
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ env.basename }}
+        path: artifacts
   windows:
     name: Windows
     needs: pre-commit
@@ -67,7 +79,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         python-arch: [x86, x64]
     steps:
     - name: Check out repo

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
     ],
     python_requires='>=3.7',


### PR DESCRIPTION
## Changes:
* Modified CI to build wheels for all relevant operating systems, as discussed in https://github.com/openslide/openslide-python/issues/187 and https://github.com/openslide/openslide-python/issues/126.
* Support for Python 3.11 was also added, both [setup.py](https://github.com/openslide/openslide-python/blob/main/setup.py) and [CI](https://github.com/openslide/openslide-python/blob/main/.github/workflows/python.yml) were modified to account for this.
* Changed to consistently write "X" instead of X for python versions in [CI](https://github.com/openslide/openslide-python/blob/main/.github/workflows/python.yml).

**Note:**
* Wheels for Python 3.12 works fine for UNIX-based systems, but as Pillow don't yet support Python 3.12 on Windows (see CI build [here](https://github.com/andreped/openslide-python/actions/runs/3670409160/jobs/6204928457)), I only set support for Python versions 3.7-3.11.
* In addition, it is likely more optimal to run tests on a separate virtual machine than where the binaries where built, to properly test that they work as intended, but I believe this is outside the scope of this PR.

**What also should be added before merge:**
- [ ] Manulinux build