### PR TITLE
workflows: use latest available Pillow wheel on Windows

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -83,6 +83,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flask pytest wheel
+        # Current Pillow releases don't have 32-bit wheels
+        # https://github.com/python-pillow/Pillow/issues/7251
+        pip install Pillow --only-binary=:all:
     - name: Install OpenSlide
       run: |
         case "${{ matrix.python-arch }}" in


### PR DESCRIPTION
Current Pillow releases no longer ship 32-bit wheels.  Rather than falling back to a source build, which fails because of missing dependencies, fall back to the latest Pillow that does have a wheel.