### PR TITLE
lowlevel: add attribute indicating whether a function is available

### DIFF
--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -45,7 +45,7 @@ from ctypes import (
 from itertools import count
 import platform
 
-import PIL.Image
+from PIL import Image
 
 from . import _convert
 
@@ -199,7 +199,7 @@ class _size_t:
 def _load_image(buf, size):
     '''buf must be a mutable buffer.'''
     _convert.argb2rgba(buf)
-    return PIL.Image.frombuffer('RGBA', size, buf, 'raw', 'RGBA', 0, 1)
+    return Image.frombuffer('RGBA', size, buf, 'raw', 'RGBA', 0, 1)
 
 
 # check for errors opening an image file and wrap the resulting handle
@@ -318,8 +318,8 @@ def read_region(slide, x, y, level, w, h):
             "negative width (%d) or negative height (%d) not allowed" % (w, h)
         )
     if w == 0 or h == 0:
-        # PIL.Image.frombuffer() would raise an exception
-        return PIL.Image.new('RGBA', (w, h))
+        # Image.frombuffer() would raise an exception
+        return Image.new('RGBA', (w, h))
     buf = (w * h * c_uint32)()
     _read_region(slide, buf, x, y, level, w, h)
     return _load_image(buf, (w, h))

--- a/tests/common.py
+++ b/tests/common.py
@@ -17,7 +17,6 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from functools import wraps
 import os
 from pathlib import Path
 
@@ -41,22 +40,6 @@ if os.name == 'nt':
 
             os.environ['PATH'] = _orig_path
 
-from openslide import OpenSlideVersionError
-
 
 def file_path(name):
     return Path(__file__).parent / 'fixtures' / name
-
-
-def maybe_supported(f):
-    '''Decorator to ignore test failures caused by an OpenSlide version that
-    doesn't support the tested functionality.'''
-
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        try:
-            return f(*args, **kwargs)
-        except OpenSlideVersionError:
-            pass
-
-    return wrapper

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,7 @@
 #
 # openslide-python - Python bindings for the OpenSlide library
 #
-# Copyright (c) 2016 Benjamin Gilbert
+# Copyright (c) 2016-2023 Benjamin Gilbert
 #
 # This library is free software; you can redistribute it and/or modify it
 # under the terms of version 2.1 of the GNU Lesser General Public License
@@ -17,11 +17,12 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import ctypes
 import unittest
 
 from common import file_path
 
-from openslide import ImageSlide, OpenSlide, open_slide
+from openslide import ImageSlide, OpenSlide, lowlevel, open_slide
 
 
 class TestLibrary(unittest.TestCase):
@@ -30,3 +31,17 @@ class TestLibrary(unittest.TestCase):
             self.assertTrue(isinstance(osr, OpenSlide))
         with open_slide(file_path('boxes.png')) as osr:
             self.assertTrue(isinstance(osr, ImageSlide))
+
+    def test_lowlevel_available(self):
+        '''Ensure all exported functions have an 'available' attribute.'''
+        for name in dir(lowlevel):
+            # ignore classes and unexported functions
+            if name.startswith('_') or name[0].isupper():
+                continue
+            # ignore random imports
+            if hasattr(ctypes, name) or name in ('count', 'platform'):
+                continue
+            self.assertTrue(
+                hasattr(getattr(lowlevel, name), 'available'),
+                f'"{name}" missing "available" attribute',
+            )

--- a/tests/test_imageslide.py
+++ b/tests/test_imageslide.py
@@ -1,7 +1,7 @@
 #
 # openslide-python - Python bindings for the OpenSlide library
 #
-# Copyright (c) 2016-2021 Benjamin Gilbert
+# Copyright (c) 2016-2023 Benjamin Gilbert
 #
 # This library is free software; you can redistribute it and/or modify it
 # under the terms of version 2.1 of the GNU Lesser General Public License
@@ -20,9 +20,9 @@
 import unittest
 
 from PIL import Image
-from common import file_path, maybe_supported
+from common import file_path
 
-from openslide import ImageSlide, OpenSlideCache, OpenSlideError
+from openslide import ImageSlide, OpenSlideCache, OpenSlideError, lowlevel
 
 
 class TestImageWithoutOpening(unittest.TestCase):
@@ -105,7 +105,7 @@ class TestImage(unittest.TestCase):
     def test_thumbnail(self):
         self.assertEqual(self.osr.get_thumbnail((100, 100)).size, (100, 83))
 
-    @maybe_supported
+    @unittest.skipUnless(lowlevel.cache_create.available, "requires OpenSlide 4.0.0")
     def test_set_cache(self):
         self.osr.set_cache(OpenSlideCache(64 << 10))
         self.assertEqual(self.osr.read_region((0, 0), 0, (400, 400)).size, (400, 400))

--- a/tests/test_openslide.py
+++ b/tests/test_openslide.py
@@ -1,7 +1,7 @@
 #
 # openslide-python - Python bindings for the OpenSlide library
 #
-# Copyright (c) 2016-2021 Benjamin Gilbert
+# Copyright (c) 2016-2023 Benjamin Gilbert
 #
 # This library is free software; you can redistribute it and/or modify it
 # under the terms of version 2.1 of the GNU Lesser General Public License
@@ -23,18 +23,19 @@ import sys
 import unittest
 
 from PIL import Image
-from common import file_path, maybe_supported
+from common import file_path
 
 from openslide import (
     OpenSlide,
     OpenSlideCache,
     OpenSlideError,
     OpenSlideUnsupportedFormatError,
+    lowlevel,
 )
 
 
 class TestCache(unittest.TestCase):
-    @maybe_supported
+    @unittest.skipUnless(lowlevel.cache_create.available, "requires OpenSlide 4.0.0")
     def test_create_cache(self):
         OpenSlideCache(0)
         OpenSlideCache(1)
@@ -155,7 +156,7 @@ class TestSlide(_SlideTest, unittest.TestCase):
     def test_thumbnail(self):
         self.assertEqual(self.osr.get_thumbnail((100, 100)).size, (100, 83))
 
-    @maybe_supported
+    @unittest.skipUnless(lowlevel.cache_create.available, "requires OpenSlide 4.0.0")
     def test_set_cache(self):
         self.osr.set_cache(OpenSlideCache(64 << 10))
         self.assertEqual(self.osr.read_region((0, 0), 0, (400, 400)).size, (400, 400))


### PR DESCRIPTION
Add `available` attribute on `lowlevel` functions to indicate whether OpenSlide supports the function, without the need to call it.  Update tests to use this; drop `maybe_supported` decorator.