### PR TITLE
examples/deepzoom: switch from optparse to argparse

### DIFF
--- a/examples/deepzoom/deepzoom_multiserver.py
+++ b/examples/deepzoom/deepzoom_multiserver.py
@@ -19,9 +19,9 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from argparse import ArgumentParser
 from collections import OrderedDict
 from io import BytesIO
-from optparse import OptionParser
 import os
 from threading import Lock
 
@@ -200,8 +200,8 @@ class _SlideFile:
 
 
 if __name__ == '__main__':
-    parser = OptionParser(usage='Usage: %prog [options] [slide-directory]')
-    parser.add_option(
+    parser = ArgumentParser(usage='%(prog)s [options] [SLIDE-DIRECTORY]')
+    parser.add_argument(
         '-B',
         '--ignore-bounds',
         dest='DEEPZOOM_LIMIT_BOUNDS',
@@ -209,32 +209,32 @@ if __name__ == '__main__':
         action='store_false',
         help='display entire scan area',
     )
-    parser.add_option(
+    parser.add_argument(
         '-c', '--config', metavar='FILE', dest='config', help='config file'
     )
-    parser.add_option(
+    parser.add_argument(
         '-d',
         '--debug',
         dest='DEBUG',
         action='store_true',
         help='run in debugging mode (insecure)',
     )
-    parser.add_option(
+    parser.add_argument(
         '-e',
         '--overlap',
         metavar='PIXELS',
         dest='DEEPZOOM_OVERLAP',
-        type='int',
+        type=int,
         help='overlap of adjacent tiles [1]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-f',
         '--format',
         metavar='{jpeg|png}',
         dest='DEEPZOOM_FORMAT',
         help='image format for tiles [jpeg]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-l',
         '--listen',
         metavar='ADDRESS',
@@ -242,45 +242,46 @@ if __name__ == '__main__':
         default='127.0.0.1',
         help='address to listen on [127.0.0.1]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-p',
         '--port',
         metavar='PORT',
         dest='port',
-        type='int',
+        type=int,
         default=5000,
         help='port to listen on [5000]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-Q',
         '--quality',
         metavar='QUALITY',
         dest='DEEPZOOM_TILE_QUALITY',
-        type='int',
+        type=int,
         help='JPEG compression quality [75]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-s',
         '--size',
         metavar='PIXELS',
         dest='DEEPZOOM_TILE_SIZE',
-        type='int',
+        type=int,
         help='tile size [254]',
     )
+    parser.add_argument(
+        'SLIDE_DIR',
+        metavar='SLIDE-DIRECTORY',
+        nargs='?',
+        help='slide directory',
+    )
 
-    (opts, args) = parser.parse_args()
+    args = parser.parse_args()
     config = {}
-    config_file = opts.config
+    config_file = args.config
     # Set only those settings specified on the command line
-    for k in dir(opts):
-        v = getattr(opts, k)
+    for k in dir(args):
+        v = getattr(args, k)
         if not k.startswith('_') and v is not None:
             config[k] = v
-    # Set slide directory if specified
-    try:
-        config['SLIDE_DIR'] = args[0]
-    except IndexError:
-        pass
     app = create_app(config, config_file)
 
-    app.run(host=opts.host, port=opts.port, threaded=True)
+    app.run(host=args.host, port=args.port, threaded=True)

--- a/examples/deepzoom/deepzoom_server.py
+++ b/examples/deepzoom/deepzoom_server.py
@@ -18,8 +18,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from argparse import ArgumentParser
 from io import BytesIO
-from optparse import OptionParser
 import os
 import re
 from unicodedata import normalize
@@ -146,8 +146,8 @@ def slugify(text):
 
 
 if __name__ == '__main__':
-    parser = OptionParser(usage='Usage: %prog [options] [slide]')
-    parser.add_option(
+    parser = ArgumentParser(usage='%(prog)s [options] [SLIDE]')
+    parser.add_argument(
         '-B',
         '--ignore-bounds',
         dest='DEEPZOOM_LIMIT_BOUNDS',
@@ -155,32 +155,32 @@ if __name__ == '__main__':
         action='store_false',
         help='display entire scan area',
     )
-    parser.add_option(
+    parser.add_argument(
         '-c', '--config', metavar='FILE', dest='config', help='config file'
     )
-    parser.add_option(
+    parser.add_argument(
         '-d',
         '--debug',
         dest='DEBUG',
         action='store_true',
         help='run in debugging mode (insecure)',
     )
-    parser.add_option(
+    parser.add_argument(
         '-e',
         '--overlap',
         metavar='PIXELS',
         dest='DEEPZOOM_OVERLAP',
-        type='int',
+        type=int,
         help='overlap of adjacent tiles [1]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-f',
         '--format',
         metavar='{jpeg|png}',
         dest='DEEPZOOM_FORMAT',
         help='image format for tiles [jpeg]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-l',
         '--listen',
         metavar='ADDRESS',
@@ -188,45 +188,46 @@ if __name__ == '__main__':
         default='127.0.0.1',
         help='address to listen on [127.0.0.1]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-p',
         '--port',
         metavar='PORT',
         dest='port',
-        type='int',
+        type=int,
         default=5000,
         help='port to listen on [5000]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-Q',
         '--quality',
         metavar='QUALITY',
         dest='DEEPZOOM_TILE_QUALITY',
-        type='int',
+        type=int,
         help='JPEG compression quality [75]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-s',
         '--size',
         metavar='PIXELS',
         dest='DEEPZOOM_TILE_SIZE',
-        type='int',
+        type=int,
         help='tile size [254]',
     )
+    parser.add_argument(
+        'DEEPZOOM_SLIDE',
+        metavar='SLIDE',
+        nargs='?',
+        help='slide file',
+    )
 
-    (opts, args) = parser.parse_args()
+    args = parser.parse_args()
     config = {}
-    config_file = opts.config
+    config_file = args.config
     # Set only those settings specified on the command line
-    for k in dir(opts):
-        v = getattr(opts, k)
+    for k in dir(args):
+        v = getattr(args, k)
         if not k.startswith('_') and v is not None:
             config[k] = v
-    # Set slide file if specified
-    try:
-        config['DEEPZOOM_SLIDE'] = args[0]
-    except IndexError:
-        pass
     app = create_app(config, config_file)
 
-    app.run(host=opts.host, port=opts.port, threaded=True)
+    app.run(host=args.host, port=args.port, threaded=True)

--- a/examples/deepzoom/deepzoom_tile.py
+++ b/examples/deepzoom/deepzoom_tile.py
@@ -21,9 +21,9 @@
 
 """An example program to generate a Deep Zoom directory tree from a slide."""
 
+from argparse import ArgumentParser
 import json
 from multiprocessing import JoinableQueue, Process
-from optparse import OptionParser
 import os
 import re
 import shutil
@@ -275,8 +275,8 @@ class DeepZoomStaticTiler:
 
 
 if __name__ == '__main__':
-    parser = OptionParser(usage='Usage: %prog [options] <slide>')
-    parser.add_option(
+    parser = ArgumentParser(usage='%(prog)s [options] <SLIDE>')
+    parser.add_argument(
         '-B',
         '--ignore-bounds',
         dest='limit_bounds',
@@ -284,16 +284,16 @@ if __name__ == '__main__':
         action='store_false',
         help='display entire scan area',
     )
-    parser.add_option(
+    parser.add_argument(
         '-e',
         '--overlap',
         metavar='PIXELS',
         dest='overlap',
-        type='int',
+        type=int,
         default=1,
         help='overlap of adjacent tiles [1]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-f',
         '--format',
         metavar='{jpeg|png}',
@@ -301,64 +301,65 @@ if __name__ == '__main__':
         default='jpeg',
         help='image format for tiles [jpeg]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-j',
         '--jobs',
         metavar='COUNT',
         dest='workers',
-        type='int',
+        type=int,
         default=4,
         help='number of worker processes to start [4]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-o',
         '--output',
         metavar='NAME',
         dest='basename',
         help='base name of output file',
     )
-    parser.add_option(
+    parser.add_argument(
         '-Q',
         '--quality',
         metavar='QUALITY',
         dest='quality',
-        type='int',
+        type=int,
         default=90,
         help='JPEG compression quality [90]',
     )
-    parser.add_option(
+    parser.add_argument(
         '-r',
         '--viewer',
         dest='with_viewer',
         action='store_true',
         help='generate directory tree with HTML viewer',
     )
-    parser.add_option(
+    parser.add_argument(
         '-s',
         '--size',
         metavar='PIXELS',
         dest='tile_size',
-        type='int',
+        type=int,
         default=254,
         help='tile size [254]',
     )
+    parser.add_argument(
+        'slidepath',
+        metavar='SLIDE',
+        help='slide file',
+    )
 
-    (opts, args) = parser.parse_args()
-    try:
-        slidepath = args[0]
-    except IndexError:
-        parser.error('Missing slide argument')
-    if opts.basename is None:
-        opts.basename = os.path.splitext(os.path.basename(slidepath))[0]
+    args = parser.parse_args()
+    if args.basename is None:
+        args.basename = os.path.splitext(os.path.basename(args.slidepath))[0]
 
     DeepZoomStaticTiler(
-        slidepath,
-        opts.basename,
-        opts.format,
-        opts.tile_size,
-        opts.overlap,
-        opts.limit_bounds,
-        opts.quality,
-        opts.workers,
-        opts.with_viewer,
+        args.slidepath,
+        args.basename,
+        args.format,
+        args.tile_size,
+        args.overlap,
+        args.limit_bounds,
+        args.quality,
+        args.workers,
+        args.with_viewer,
     ).run()


### PR DESCRIPTION
optparse is deprecated, and argparse is available on all supported Python versions.