### PR TITLE
workflows/dco-report: drop permissions

### DIFF
--- a/.github/workflows/dco-report.yml
+++ b/.github/workflows/dco-report.yml
@@ -6,6 +6,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: none
+
 jobs:
   comment:
     name: Organization


### PR DESCRIPTION
Ensure the workflow doesn't get write access in forks configured to give it by default.

Update for https://github.com/openslide/.github/pull/4.