### PR TITLE
Default to default rendering intent from slide ICC profile

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -213,22 +213,21 @@ To include the profile in an image file when saving the image to disk::
     image.save(filename, icc_profile=image.info.get('icc_profile'))
 
 To perform color conversions using the profile, import it into
-:mod:`ImageCms <PIL.ImageCms>`.  For example, to convert an image in-place
-to a synthesized sRGB profile, using absolute colorimetric rendering::
+:mod:`ImageCms <PIL.ImageCms>`.  For example, to synthesize an sRGB profile
+and use it to transform an image for display, with the default rendering
+intent of the image's profile::
 
     from io import BytesIO
     from PIL import ImageCms
 
     fromProfile = ImageCms.getOpenProfile(BytesIO(image.info['icc_profile']))
     toProfile = ImageCms.createProfile('sRGB')
+    intent = ImageCms.getDefaultIntent(fromProfile)
     ImageCms.profileToProfile(
-        image, fromProfile, toProfile,
-        ImageCms.Intent.ABSOLUTE_COLORIMETRIC, 'RGBA', True, 0
+        image, fromProfile, toProfile, intent, 'RGBA', True, 0
     )
 
-Absolute colorimetric rendering `maximizes the comparability`_ of images
-produced by different scanners.  When converting Deep Zoom tiles, use
-``'RGB'`` instead of ``'RGBA'``.
+When converting Deep Zoom tiles, use ``'RGB'`` instead of ``'RGBA'``.
 
 All pyramid regions in a slide have the same profile, but each associated
 image can have its own profile.  As a convenience, the former is also
@@ -238,14 +237,12 @@ by building an :class:`~PIL.ImageCms.ImageCmsTransform` for the slide and
 reusing it for multiple slide regions::
 
     toProfile = ImageCms.createProfile('sRGB')
+    intent = ImageCms.getDefaultIntent(slide.color_profile)
     transform = ImageCms.buildTransform(
-        slide.color_profile, toProfile, 'RGBA', 'RGBA',
-        ImageCms.Intent.ABSOLUTE_COLORIMETRIC, 0
+        slide.color_profile, toProfile, 'RGBA', 'RGBA', intent, 0
     )
     # for each region image:
     ImageCms.applyTransform(image, transform, True)
-
-.. _maximizes the comparability: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4478790/
 
 
 Caching

--- a/examples/deepzoom/deepzoom_multiserver.py
+++ b/examples/deepzoom/deepzoom_multiserver.py
@@ -73,7 +73,7 @@ def create_app(config=None, config_file=None):
         DEEPZOOM_OVERLAP=1,
         DEEPZOOM_LIMIT_BOUNDS=True,
         DEEPZOOM_TILE_QUALITY=75,
-        DEEPZOOM_COLOR_MODE='absolute-colorimetric',
+        DEEPZOOM_COLOR_MODE='default',
     )
     app.config.from_envvar('DEEPZOOM_MULTISERVER_SETTINGS', silent=True)
     if config_file is not None:
@@ -212,6 +212,8 @@ class _SlideCache:
         elif mode == 'embed':
             # embed ICC profile in tiles
             return lambda img: None
+        elif mode == 'default':
+            intent = ImageCms.getDefaultIntent(image.color_profile)
         elif mode == 'absolute-colorimetric':
             intent = ImageCms.Intent.ABSOLUTE_COLORIMETRIC
         elif mode == 'relative-colorimetric':
@@ -276,6 +278,7 @@ if __name__ == '__main__':
         '--color-mode',
         dest='DEEPZOOM_COLOR_MODE',
         choices=[
+            'default',
             'absolute-colorimetric',
             'perceptual',
             'relative-colorimetric',
@@ -283,11 +286,11 @@ if __name__ == '__main__':
             'embed',
             'ignore',
         ],
-        default='absolute-colorimetric',
+        default='default',
         help=(
-            'convert tiles to sRGB using specified rendering intent, or '
-            'embed original ICC profile, or ignore ICC profile (compat) '
-            '[absolute-colorimetric]'
+            'convert tiles to sRGB using default rendering intent of ICC '
+            'profile, or specified rendering intent; or embed original '
+            'ICC profile; or ignore ICC profile (compat) [default]'
         ),
     )
     parser.add_argument(

--- a/examples/deepzoom/deepzoom_server.py
+++ b/examples/deepzoom/deepzoom_server.py
@@ -73,7 +73,7 @@ def create_app(config=None, config_file=None):
         DEEPZOOM_OVERLAP=1,
         DEEPZOOM_LIMIT_BOUNDS=True,
         DEEPZOOM_TILE_QUALITY=75,
-        DEEPZOOM_COLOR_MODE='absolute-colorimetric',
+        DEEPZOOM_COLOR_MODE='default',
     )
     app.config.from_envvar('DEEPZOOM_TILER_SETTINGS', silent=True)
     if config_file is not None:
@@ -182,6 +182,8 @@ def get_transform(image, mode):
     elif mode == 'embed':
         # embed ICC profile in tiles
         return lambda img: None
+    elif mode == 'default':
+        intent = ImageCms.getDefaultIntent(image.color_profile)
     elif mode == 'absolute-colorimetric':
         intent = ImageCms.Intent.ABSOLUTE_COLORIMETRIC
     elif mode == 'relative-colorimetric':
@@ -224,6 +226,7 @@ if __name__ == '__main__':
         '--color-mode',
         dest='DEEPZOOM_COLOR_MODE',
         choices=[
+            'default',
             'absolute-colorimetric',
             'perceptual',
             'relative-colorimetric',
@@ -231,11 +234,11 @@ if __name__ == '__main__':
             'embed',
             'ignore',
         ],
-        default='absolute-colorimetric',
+        default='default',
         help=(
-            'convert tiles to sRGB using specified rendering intent, or '
-            'embed original ICC profile, or ignore ICC profile (compat) '
-            '[absolute-colorimetric]'
+            'convert tiles to sRGB using default rendering intent of ICC '
+            'profile, or specified rendering intent; or embed original '
+            'ICC profile; or ignore ICC profile (compat) [default]'
         ),
     )
     parser.add_argument(

--- a/examples/deepzoom/deepzoom_tile.py
+++ b/examples/deepzoom/deepzoom_tile.py
@@ -125,6 +125,8 @@ class TileWorker(Process):
         elif mode == 'embed':
             # embed ICC profile in tiles
             return lambda img: None
+        elif mode == 'default':
+            intent = ImageCms.getDefaultIntent(image.color_profile)
         elif mode == 'absolute-colorimetric':
             intent = ImageCms.Intent.ABSOLUTE_COLORIMETRIC
         elif mode == 'relative-colorimetric':
@@ -356,6 +358,7 @@ if __name__ == '__main__':
         '--color-mode',
         dest='color_mode',
         choices=[
+            'default',
             'absolute-colorimetric',
             'perceptual',
             'relative-colorimetric',
@@ -363,11 +366,11 @@ if __name__ == '__main__':
             'embed',
             'ignore',
         ],
-        default='absolute-colorimetric',
+        default='default',
         help=(
-            'convert tiles to sRGB using specified rendering intent, or '
-            'embed original ICC profile, or ignore ICC profile (compat) '
-            '[absolute-colorimetric]'
+            'convert tiles to sRGB using default rendering intent of ICC '
+            'profile, or specified rendering intent; or embed original '
+            'ICC profile; or ignore ICC profile (compat) [default]'
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
ICC profiles don't necessarily support all rendering intents, and aren't necessarily optimized for all the intents they do support.  They can also be queried for the rendering intent recommended by the profile creator. Use that by default, instead of absolute colorimetric.