### PR TITLE
templates/release: add additional package repos

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -11,6 +11,7 @@
 - [ ] Attach release notes to [GitHub release](https://github.com/openslide/openslide-python/releases/new); upload tarballs and wheels
 - [ ] `cd` into website checkout; `rm -r api/python && unzip /path/to/downloaded/openslide-python-docs.zip && mv openslide-python-docs-* api/python`
 - [ ] Update website: `_data/releases.yaml`, `_includes/news.md`
+- [ ] Update Ubuntu PPA
 - [ ] Send mail to -announce and -users
-- [ ] Update Fedora package
+- [ ] Update Fedora and EPEL packages
 - [ ] Update MacPorts package


### PR DESCRIPTION
The Fedora package has EPEL branches, and we now have an Ubuntu PPA. Update the PPA before sending announce mail so users can upgrade immediately.