### PR TITLE
convert: use Python Limited API on Python 3.11 and above

### DIFF
--- a/.github/ISSUE_TEMPLATE/python-bump.md
+++ b/.github/ISSUE_TEMPLATE/python-bump.md
@@ -1,4 +1,4 @@
-# Adding wheels for a new Python release
+# Adding a new Python release
 
 - Update Git main
   - [ ] `git checkout main`
@@ -7,14 +7,5 @@
   - [ ] Commit and open a PR
   - [ ] Merge the PR when CI passes
   - [ ] Add new Python jobs to [branch protection required checks](https://github.com/openslide/openslide-python/settings/branches)
-- Build new wheels
-  - [ ] Check out a new branch from the most recent release tag
-  - [ ] Add new Python version to lists in `.github/workflows/python.yml`, commit, and open a DNM PR
-  - [ ] Find the [workflow run](https://github.com/openslide/openslide-python/actions) for the PR; download its wheels artifact
-  - [ ] Close the PR
-- [ ] In OpenSlide Python checkout, `git checkout v<version> && git clean -dxf && mkdir dist`
-- [ ] Copy downloaded wheels _from new Python release only_ into `dist` directory
-- [ ] `twine upload dist/*`
-- [ ] Upload new wheels to [GitHub release](https://github.com/openslide/openslide-python/releases)
 - [ ] Update MacPorts package
 - [ ] Update website: Python 3 versions in `download/index.md`

--- a/.github/ISSUE_TEMPLATE/python-bump.md
+++ b/.github/ISSUE_TEMPLATE/python-bump.md
@@ -2,7 +2,7 @@
 
 - Update Git main
   - [ ] `git checkout main`
-  - [ ] Add classifier for new Python version to `setup.py`
+  - [ ] Add classifier for new Python version to `pyproject.toml'
   - [ ] Add new Python version to lists in `.github/workflows/python.yml`
   - [ ] Commit and open a PR
   - [ ] Merge the PR when CI passes

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -106,6 +106,9 @@ jobs:
         mkdir -p "artifacts/${basename}"
         mv dist/* "artifacts/${basename}"
         echo "basename=${basename}" >> $GITHUB_ENV
+        # save version-specific wheels and oldest abi3 wheel
+        python -c 'import sys
+        if sys.version_info < (3, 12): print("archive_wheel=1")' >> $GITHUB_ENV
     - name: Install
       run: pip install artifacts/${basename}/*.whl
     - name: Run tests
@@ -113,6 +116,7 @@ jobs:
     - name: Tile slide
       run: python examples/deepzoom/deepzoom_tile.py --viewer -o tiled tests/fixtures/small.svs
     - name: Archive wheel
+      if: env.archive_wheel
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.basename }}
@@ -155,6 +159,9 @@ jobs:
         mkdir -p "artifacts/${basename}"
         mv dist/*.whl "artifacts/${basename}"
         echo "basename=${basename}" >> $GITHUB_ENV
+        # save version-specific wheels and oldest abi3 wheel
+        python -c 'import sys
+        if sys.version_info < (3, 12): print("archive_wheel=1")' >> $GITHUB_ENV
     - name: Install
       run: pip install artifacts/${basename}/*.whl
     - name: Run tests
@@ -170,6 +177,7 @@ jobs:
       # Reads OPENSLIDE_PATH
       run: python examples/deepzoom/deepzoom_tile.py --viewer -o tiled tests/fixtures/small.svs
     - name: Archive wheel
+      if: env.archive_wheel
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.basename }}

--- a/openslide/_convert.c
+++ b/openslide/_convert.c
@@ -89,7 +89,7 @@ _convert_argb2rgba(PyObject *self, PyObject *args)
     argb2rgba(view.buf, view.len / 4);
     Py_END_ALLOW_THREADS
 
-    Py_INCREF(Py_None);
+    Py_IncRef(Py_None);
     ret = Py_None;
 
 DONE:
@@ -114,5 +114,5 @@ static struct PyModuleDef convertmodule = {
 PyMODINIT_FUNC
 PyInit__convert(void)
 {
-    return PyModule_Create(&convertmodule);
+    return PyModule_Create2(&convertmodule, PYTHON_API_VERSION);
 }

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,26 @@
+import sys
+
 from setuptools import Extension, setup
+
+# use the Limited API on Python 3.11+; build release-specific wheels on
+# older Python
+_abi3 = sys.version_info >= (3, 11)
 
 setup(
     ext_modules=[
-        Extension('openslide._convert', ['openslide/_convert.c']),
+        Extension(
+            'openslide._convert',
+            ['openslide/_convert.c'],
+            # hide symbols that aren't in the Limited API
+            define_macros=[('Py_LIMITED_API', '0x030b0000')] if _abi3 else [],
+            # tag extension module for Limited API
+            py_limited_api=_abi3,
+        ),
     ],
+    options={
+        # tag wheel for Limited API
+        'bdist_wheel': {'py_limited_api': 'cp311'}
+        if _abi3
+        else {},
+    },
 )


### PR DESCRIPTION
This allows us to produce forward-compatible wheels and stop building new wheels for every Python minor release.  The buffer protocol API was added to the Limited API in 3.11, so we still need version-specific wheels for releases older than that.

Replace a couple functions that aren't in the Stable API with equivalents that are.
