### PR TITLE
Remove MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-include *.md
-recursive-include doc *.py *.rst
-recursive-include examples *.html *.js *.png *.py
-recursive-include tests *.dcm *.png *.py *.svs *.tiff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,12 @@ packages = ["openslide"]
 [tool.setuptools.dynamic]
 version = {attr = "openslide._version.__version__"}
 
+[tool.setuptools.package-data]
+"*" = ["*.md"]
+doc = ["*.py", "*.rst"]
+example = ["*.html", "*.js", "*.png", "*.py"]
+tests = ["*.dcm", "*.png", "*.py", "*.svs", "*.tiff"]
+
 [tool.black]
 skip-string-normalization = true
 target-version = ["py38", "py39", "py310", "py311", "py312"]


### PR DESCRIPTION
Use setuptools.package-data to indicate which files should be included in the sdist and wheel packages.

I checked the file list in the wheel before and after the patch and they matched up. The sdist file is different because it no longer has MANIFEST.in after this patch, but all other included files are still the same.