### PR TITLE
workflows: automatically publish releases to PyPI and GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -6,8 +6,7 @@
 - [ ] Find the [workflow run](https://github.com/openslide/openslide-python/actions/workflows/python.yml) for the tag; download its dist and docs artifacts
 - [ ] `unzip /path/to/downloaded/openslide-python-dist.zip && mv openslide-python-dist-*/* dist/`
 - [ ] `twine upload dist/*`
-- [ ] Recompress tarball with `xz`
-- [ ] Attach release notes to [GitHub release](https://github.com/openslide/openslide-python/releases/new); upload tarballs and wheels
+- [ ] Verify that the workflow created a [GitHub release](https://github.com/openslide/openslide-python/releases) with release notes, a source tarball, and wheels
 - [ ] `cd` into website checkout; `rm -r api/python && unzip /path/to/downloaded/openslide-python-docs.zip && mv openslide-python-docs-* api/python`
 - [ ] Update website: `_data/releases.yaml`, `_includes/news.md`
 - [ ] Update Ubuntu PPA

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -2,10 +2,10 @@
 
 - [ ] Update `CHANGELOG.md` and version in `openslide/_version.py`
 - [ ] Create and push signed tag
-- [ ] `git clean -dxf && mkdir dist`
-- [ ] Find the [workflow run](https://github.com/openslide/openslide-python/actions/workflows/python.yml) for the tag; download its dist and docs artifacts
-- [ ] `unzip /path/to/downloaded/openslide-python-dist.zip && mv openslide-python-dist-*/* dist/`
-- [ ] `twine upload dist/*`
+- [ ] Find the [workflow run](https://github.com/openslide/openslide-python/actions/workflows/python.yml) for the tag
+  - [ ] Once the build finishes, approve deployment to PyPI
+  - [ ] Download the docs artifact
+- [ ] Verify that the workflow created a [PyPI release](https://pypi.org/p/openslide-python) with a description, source tarball, and wheels
 - [ ] Verify that the workflow created a [GitHub release](https://github.com/openslide/openslide-python/releases) with release notes, a source tarball, and wheels
 - [ ] `cd` into website checkout; `rm -r api/python && unzip /path/to/downloaded/openslide-python-docs.zip && mv openslide-python-docs-* api/python`
 - [ ] Update website: `_data/releases.yaml`, `_includes/news.md`

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -218,3 +218,37 @@ jobs:
       with:
         name: ${{ needs.pre-commit.outputs.docs-base }}
         path: artifact
+
+  release:
+    name: Release
+    if: github.ref_type == 'tag'
+    needs: [pre-commit, tests, windows]
+    runs-on: ubuntu-latest
+    concurrency: release-${{ github.ref }}
+    permissions:
+      contents: write
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ needs.pre-commit.outputs.dist-base }}
+    - name: Release to GitHub
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        version=$(echo "${{ github.ref_name }}" | sed "s/^v//")
+        # recompress tarball with xz
+        gunzip -k "${{ needs.pre-commit.outputs.dist-base }}/openslide-python-${version}.tar.gz"
+        tar xf "${{ needs.pre-commit.outputs.dist-base }}/openslide-python-${version}.tar"
+        xz -9 "${{ needs.pre-commit.outputs.dist-base }}/openslide-python-${version}.tar"
+        # extract changelog
+        awk -e '/^## / && ok {exit}' \
+            -e '/^## / {ok=1; next}' \
+            -e 'ok {print}' \
+            "openslide-python-$version/CHANGELOG.md" > changes
+        gh release create --latest --verify-tag \
+            --repo "${{ github.repository }}" \
+            --title "OpenSlide Python $version" \
+            --notes-file changes \
+            "${{ github.ref_name }}" \
+            "${{ needs.pre-commit.outputs.dist-base }}/"*

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -222,16 +222,24 @@ jobs:
   release:
     name: Release
     if: github.ref_type == 'tag'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/openslide-python
     needs: [pre-commit, tests, windows]
     runs-on: ubuntu-latest
     concurrency: release-${{ github.ref }}
     permissions:
       contents: write
+      id-token: write
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v3
       with:
         name: ${{ needs.pre-commit.outputs.dist-base }}
+    - name: Release to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: ${{ needs.pre-commit.outputs.dist-base }}
     - name: Release to GitHub
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Use PyPI's [trusted publisher mechanism](https://docs.pypi.org/trusted-publishers/), which is configured to require deploying via a GitHub environment, which is configured to require manual approval.