### PR TITLE
Update lowlevel.py

### DIFF
--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -43,6 +43,7 @@ from ctypes import (
     c_void_p,
     cdll,
 )
+from ctypes.util import find_library
 from itertools import count
 import platform
 
@@ -55,7 +56,7 @@ def _load_library():
     def try_load(names):
         for name in names:
             try:
-                return cdll.LoadLibrary(name)
+                return cdll.LoadLibrary(find_library(name))
             except OSError:
                 if name == names[-1]:
                     raise


### PR DESCRIPTION
Adding in ctypes.util.find_library to enable cdll to find and load in the DLLs that were stored in windows environment variables. Apparently after Python 3.8 your environment variable's path is not searched for DLLs. This allows people to have the bin path added to environment variables for importing openslide without having to use the hacky os.add_dll_directory() method. Also enables sub-processes initiated by Python's multiprocessing package to properly import openslide.