### PR TITLE
workflows: get PyPI upload URL from var in GitHub environment

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -240,6 +240,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         packages-dir: ${{ needs.pre-commit.outputs.dist-base }}
+        repository-url: ${{ vars.PYPI_URL }}
     - name: Release to GitHub
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Make it easier for forks to upload to TestPyPI.