### PR TITLE
workflows: skip installing setuptools

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Install Python tools
       run: |
         python -m pip install --upgrade pip
-        pip install auditwheel build jinja2 pytest setuptools
+        pip install auditwheel build jinja2 pytest
     - name: Install OpenSlide
       run: |
         case "${{ matrix.os }}" in


### PR DESCRIPTION
auditwheel 6.0.0 no longer requires it.