### PR TITLE
Add type hints to `openslide` package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
       - id: mypy
         name: Check Python types
         additional_dependencies: [openslide-bin, pillow, types-setuptools]
-        exclude: "^(doc/.*|openslide/(__init__|deepzoom)\\.py|tests/.*|examples/deepzoom/.*)$"
+        exclude: "^(doc/.*|tests/.*|examples/deepzoom/.*)$"
 
   - repo: https://github.com/rstcheck/rstcheck
     rev: v6.2.4

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -366,7 +366,7 @@ class ImageSlide(AbstractSlide):
         self._file_arg = file
         if isinstance(file, Image.Image):
             self._close = False
-            self._image = file
+            self._image: Image.Image | None = file
         else:
             self._close = True
             self._image = Image.open(file)
@@ -391,10 +391,10 @@ class ImageSlide(AbstractSlide):
     def close(self) -> None:
         """Close the slide object."""
         if self._close:
+            assert self._image is not None
             self._image.close()
             self._close = False
-        # is it necessary to set to None?
-        self._image = None  # type: ignore
+        self._image = None
 
     @property
     def level_count(self) -> Literal[1]:
@@ -406,6 +406,8 @@ class ImageSlide(AbstractSlide):
         """A list of (width, height) tuples, one for each level of the image.
 
         level_dimensions[n] contains the dimensions of level n."""
+        if self._image is None:
+            raise ValueError('Passing closed slide object')
         return (self._image.size,)
 
     @property
@@ -442,6 +444,8 @@ class ImageSlide(AbstractSlide):
                   reference frame.
         level:    the level number.
         size:     (width, height) tuple giving the region size."""
+        if self._image is None:
+            raise ValueError('Passing closed slide object')
         if level != 0:
             raise OpenSlideError("Invalid level")
         if ['fail' for s in size if s < 0]:

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -69,7 +69,7 @@ class AbstractSlide:
     """The base class of a slide object."""
 
     def __init__(self) -> None:
-        self._profile = None
+        self._profile: bytes | None = None
 
     def __enter__(self) -> AbstractSlide:
         return self
@@ -387,7 +387,9 @@ class ImageSlide(AbstractSlide):
         If the file format is not recognized, return None."""
         try:
             with Image.open(filename) as img:
-                return img.format
+                # img currently resolves as Any
+                # https://github.com/python-pillow/Pillow/pull/8362
+                return img.format  # type: ignore[no-any-return]
         except OSError:
             return None
 

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -239,14 +239,14 @@ class OpenSlide(AbstractSlide):
         )
 
     @property
-    def properties(self) -> _OpenSlideMap[str]:
+    def properties(self) -> Mapping[str, str]:
         """Metadata about the image.
 
         This is a map: property name -> property value."""
         return _PropertyMap(self._osr)
 
     @property
-    def associated_images(self) -> _OpenSlideMap[Image.Image]:
+    def associated_images(self) -> Mapping[str, Image.Image]:
         """Images associated with this whole-slide image.
 
         This is a map: image name -> PIL.Image.
@@ -291,10 +291,7 @@ class OpenSlide(AbstractSlide):
         lowlevel.set_cache(self._osr, llcache)
 
 
-MapValue = TypeVar('MapValue', str, Image.Image)
-
-
-class _OpenSlideMap(Mapping[str, MapValue]):
+class _OpenSlideMap(Mapping[str, _T]):
     def __init__(self, osr: lowlevel._OpenSlide):
         self._osr = osr
 
@@ -423,14 +420,14 @@ class ImageSlide(AbstractSlide):
         return (1.0,)
 
     @property
-    def properties(self) -> dict[str, str]:
+    def properties(self) -> Mapping[str, str]:
         """Metadata about the image.
 
         This is a map: property name -> property value."""
         return {}
 
     @property
-    def associated_images(self) -> dict[str, Image.Image]:
+    def associated_images(self) -> Mapping[str, Image.Image]:
         """Images associated with this whole-slide image.
 
         This is a map: image name -> PIL.Image."""

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -60,6 +60,8 @@ PROPERTY_NAME_BOUNDS_Y = 'openslide.bounds-y'
 PROPERTY_NAME_BOUNDS_WIDTH = 'openslide.bounds-width'
 PROPERTY_NAME_BOUNDS_HEIGHT = 'openslide.bounds-height'
 
+_T = TypeVar('_T')
+
 
 class _OpenSlideCacheWrapper(Protocol):
     _openslide_cache: lowlevel._OpenSlideCache
@@ -71,7 +73,7 @@ class AbstractSlide:
     def __init__(self) -> None:
         self._profile: bytes | None = None
 
-    def __enter__(self) -> AbstractSlide:
+    def __enter__(self: _T) -> _T:
         return self
 
     def __exit__(

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -402,7 +402,7 @@ class ImageSlide(AbstractSlide):
         return 1
 
     @property
-    def level_dimensions(self) -> tuple[tuple[int, int], ...]:
+    def level_dimensions(self) -> tuple[tuple[int, int]]:
         """A list of (width, height) tuples, one for each level of the image.
 
         level_dimensions[n] contains the dimensions of level n."""
@@ -411,7 +411,7 @@ class ImageSlide(AbstractSlide):
         return (self._image.size,)
 
     @property
-    def level_downsamples(self) -> tuple[float, ...]:
+    def level_downsamples(self) -> tuple[float]:
         """A list of downsampling factors for each level of the image.
 
         level_downsample[n] contains the downsample factor of level n."""

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -86,7 +86,7 @@ class AbstractSlide:
         return False
 
     @classmethod
-    def detect_format(cls, filename: Path | str) -> str | None:
+    def detect_format(cls, filename: str | Path) -> str | None:
         """Return a string describing the format of the specified file.
 
         If the file format is not recognized, return None."""
@@ -193,7 +193,7 @@ class OpenSlide(AbstractSlide):
     operations on the OpenSlide object, other than close(), will fail.
     """
 
-    def __init__(self, filename: Path | str | bytes) -> None:
+    def __init__(self, filename: str | Path) -> None:
         """Open a whole-slide image."""
         AbstractSlide.__init__(self)
         self._filename = filename
@@ -205,7 +205,7 @@ class OpenSlide(AbstractSlide):
         return f'{self.__class__.__name__}({self._filename!r})'
 
     @classmethod
-    def detect_format(cls, filename: Path | str) -> str | None:
+    def detect_format(cls, filename: str | Path) -> str | None:
         """Return a string describing the format vendor of the specified file.
 
         If the file format is not recognized, return None."""
@@ -365,7 +365,7 @@ class OpenSlideCache:
 class ImageSlide(AbstractSlide):
     """A wrapper for a PIL.Image that provides the OpenSlide interface."""
 
-    def __init__(self, file: str | bytes | Path | Image.Image):
+    def __init__(self, file: str | Path | Image.Image):
         """Open an image file.
 
         file can be a filename or a PIL.Image."""
@@ -383,7 +383,7 @@ class ImageSlide(AbstractSlide):
         return f'{self.__class__.__name__}({self._file_arg!r})'
 
     @classmethod
-    def detect_format(cls, filename: str | bytes | Path) -> str | None:
+    def detect_format(cls, filename: str | Path) -> str | None:
         """Return a string describing the format of the specified file.
 
         If the file format is not recognized, return None."""
@@ -492,7 +492,7 @@ class ImageSlide(AbstractSlide):
         pass
 
 
-def open_slide(filename: str | bytes | Path) -> AbstractSlide:
+def open_slide(filename: str | Path) -> AbstractSlide:
     """Open a whole-slide or regular image.
 
     Return an OpenSlide object for whole-slide images and an ImageSlide

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -189,7 +189,7 @@ class OpenSlide(AbstractSlide):
     operations on the OpenSlide object, other than close(), will fail.
     """
 
-    def __init__(self, filename: str | Path) -> None:
+    def __init__(self, filename: str | Path):
         """Open a whole-slide image."""
         AbstractSlide.__init__(self)
         self._filename = filename

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -492,7 +492,7 @@ class ImageSlide(AbstractSlide):
         pass
 
 
-def open_slide(filename: str | Path) -> AbstractSlide:
+def open_slide(filename: str | Path) -> OpenSlide | ImageSlide:
     """Open a whole-slide or regular image.
 
     Return an OpenSlide object for whole-slide images and an ImageSlide

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from io import BytesIO
 from pathlib import Path
 from types import TracebackType
-from typing import Iterator, Literal, Mapping, Protocol, TypeVar
+from typing import Iterator, Literal, Mapping, TypeVar
 
 from PIL import Image, ImageCms
 
@@ -61,10 +61,6 @@ PROPERTY_NAME_BOUNDS_WIDTH = 'openslide.bounds-width'
 PROPERTY_NAME_BOUNDS_HEIGHT = 'openslide.bounds-height'
 
 _T = TypeVar('_T')
-
-
-class _OpenSlideCacheWrapper(Protocol):
-    _openslide_cache: lowlevel._OpenSlideCache
 
 
 class AbstractSlide:
@@ -156,7 +152,7 @@ class AbstractSlide:
         size:     (width, height) tuple giving the region size."""
         raise NotImplementedError
 
-    def set_cache(self, cache: _OpenSlideCacheWrapper) -> None:
+    def set_cache(self, cache: OpenSlideCache) -> None:
         """Use the specified cache to store recently decoded slide tiles.
 
         cache: an OpenSlideCache object."""
@@ -278,7 +274,7 @@ class OpenSlide(AbstractSlide):
             region.info['icc_profile'] = self._profile
         return region
 
-    def set_cache(self, cache: _OpenSlideCacheWrapper) -> None:
+    def set_cache(self, cache: OpenSlideCache) -> None:
         """Use the specified cache to store recently decoded slide tiles.
 
         By default, the object has a private cache with a default size.
@@ -480,7 +476,7 @@ class ImageSlide(AbstractSlide):
             tile.info['icc_profile'] = self._profile
         return tile
 
-    def set_cache(self, cache: _OpenSlideCacheWrapper) -> None:
+    def set_cache(self, cache: OpenSlideCache) -> None:
         """Use the specified cache to store recently decoded slide tiles.
 
         ImageSlide does not support caching, so this method does nothing.

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -466,15 +466,10 @@ class ImageSlide(AbstractSlide):
         ]:  # "< 0" not a typo
             # Crop size is greater than zero in both dimensions.
             # PIL thinks the bottom right is the first *excluded* pixel
-            crop = self._image.crop(
-                (
-                    image_topleft[0],
-                    image_topleft[1],
-                    image_bottomright[0] + 1,
-                    image_bottomright[1] + 1,
-                )
-            )
-            tile_offset = image_topleft[0] - location[0], image_topleft[1] - location[1]
+            crop_box = tuple(image_topleft + [d + 1 for d in image_bottomright])
+            tile_offset = tuple(il - l for il, l in zip(image_topleft, location))
+            assert len(crop_box) == 4 and len(tile_offset) == 2
+            crop = self._image.crop(crop_box)
             tile.paste(crop, tile_offset)
         if self._profile is not None:
             tile.info['icc_profile'] = self._profile

--- a/openslide/deepzoom.py
+++ b/openslide/deepzoom.py
@@ -46,7 +46,13 @@ class DeepZoomGenerator:
         openslide.PROPERTY_NAME_BOUNDS_HEIGHT,
     )
 
-    def __init__(self, osr, tile_size=254, overlap=1, limit_bounds=False):
+    def __init__(
+        self,
+        osr: openslide.AbstractSlide,
+        tile_size: int = 254,
+        overlap: int = 1,
+        limit_bounds: bool = False,
+    ):
         """Create a DeepZoomGenerator wrapping an OpenSlide object.
 
         osr:          a slide object.
@@ -101,7 +107,7 @@ class DeepZoomGenerator:
         self._z_dimensions = tuple(reversed(z_dimensions))
 
         # Tile
-        def tiles(z_lim):
+        def tiles(z_lim: int) -> int:
             return int(math.ceil(z_lim / self._z_t_downsample))
 
         self._t_dimensions = tuple(
@@ -112,7 +118,8 @@ class DeepZoomGenerator:
         self._dz_levels = len(self._z_dimensions)
 
         # Total downsamples for each Deep Zoom level
-        l0_z_downsamples = tuple(
+        # mypy infers this as a tuple[Any, ...] due to the ** operator
+        l0_z_downsamples: tuple[int, ...] = tuple(
             2 ** (self._dz_levels - dz_level - 1) for dz_level in range(self._dz_levels)
         )
 
@@ -134,7 +141,7 @@ class DeepZoomGenerator:
             openslide.PROPERTY_NAME_BACKGROUND_COLOR, 'ffffff'
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '{}({!r}, tile_size={!r}, overlap={!r}, limit_bounds={!r})'.format(
             self.__class__.__name__,
             self._osr,
@@ -144,26 +151,26 @@ class DeepZoomGenerator:
         )
 
     @property
-    def level_count(self):
+    def level_count(self) -> int:
         """The number of Deep Zoom levels in the image."""
         return self._dz_levels
 
     @property
-    def level_tiles(self):
+    def level_tiles(self) -> tuple[tuple[int, int], ...]:
         """A list of (tiles_x, tiles_y) tuples for each Deep Zoom level."""
         return self._t_dimensions
 
     @property
-    def level_dimensions(self):
+    def level_dimensions(self) -> tuple[tuple[int, ...], ...]:
         """A list of (pixels_x, pixels_y) tuples for each Deep Zoom level."""
         return self._z_dimensions
 
     @property
-    def tile_count(self):
+    def tile_count(self) -> int:
         """The total number of Deep Zoom tiles in the image."""
         return sum(t_cols * t_rows for t_cols, t_rows in self._t_dimensions)
 
-    def get_tile(self, level, address):
+    def get_tile(self, level: int, address: tuple[int, int]) -> Image.Image:
         """Return an RGB PIL.Image for a tile.
 
         level:     the Deep Zoom level.
@@ -191,7 +198,9 @@ class DeepZoomGenerator:
 
         return tile
 
-    def _get_tile_info(self, dz_level, t_location):
+    def _get_tile_info(
+        self, dz_level: int, t_location: tuple[int, int]
+    ) -> tuple[tuple[tuple[int, int], int, tuple[int, int]], tuple[int, int]]:
         # Check parameters
         if dz_level < 0 or dz_level >= self._dz_levels:
             raise ValueError("Invalid level")
@@ -210,42 +219,62 @@ class DeepZoomGenerator:
         )
 
         # Get final size of the tile
-        z_size = tuple(
-            min(self._z_t_downsample, z_lim - self._z_t_downsample * t) + z_tl + z_br
-            for t, z_lim, z_tl, z_br in zip(
-                t_location, self._z_dimensions[dz_level], z_overlap_tl, z_overlap_br
+        z_size = (
+            min(
+                self._z_t_downsample,
+                self._z_dimensions[dz_level][0] - self._z_t_downsample * t_location[0],
             )
+            + z_overlap_tl[0]
+            + z_overlap_br[0],
+            min(
+                self._z_t_downsample,
+                self._z_dimensions[dz_level][1] - self._z_t_downsample * t_location[1],
+            )
+            + z_overlap_tl[1]
+            + z_overlap_br[1],
         )
 
         # Obtain the region coordinates
-        z_location = [self._z_from_t(t) for t in t_location]
-        l_location = [
-            self._l_from_z(dz_level, z - z_tl)
-            for z, z_tl in zip(z_location, z_overlap_tl)
-        ]
-        # Round location down and size up, and add offset of active area
-        l0_location = tuple(
-            int(self._l0_from_l(slide_level, l) + l0_off)
-            for l, l0_off in zip(l_location, self._l0_offset)
+        z_location = (self._z_from_t(t_location[0]), self._z_from_t(t_location[1]))
+        l_location = (
+            self._l_from_z(dz_level, z_location[0] - z_overlap_tl[0]),
+            self._l_from_z(dz_level, z_location[1] - z_overlap_tl[1]),
         )
-        l_size = tuple(
-            int(min(math.ceil(self._l_from_z(dz_level, dz)), l_lim - math.ceil(l)))
-            for l, dz, l_lim in zip(l_location, z_size, self._l_dimensions[slide_level])
+        # Round location down and size up, and add offset of active area
+        l0_location = (
+            int(self._l0_from_l(slide_level, l_location[0]) + self._l0_offset[0]),
+            int(self._l0_from_l(slide_level, l_location[1]) + self._l0_offset[1]),
+        )
+        l_size = (
+            int(
+                min(
+                    math.ceil(self._l_from_z(dz_level, z_size[0])),
+                    self._l_dimensions[slide_level][0] - math.ceil(l_location[0]),
+                )
+            ),
+            int(
+                min(
+                    math.ceil(self._l_from_z(dz_level, z_size[1])),
+                    self._l_dimensions[slide_level][1] - math.ceil(l_location[1]),
+                )
+            ),
         )
 
         # Return read_region() parameters plus tile size for final scaling
         return ((l0_location, slide_level, l_size), z_size)
 
-    def _l0_from_l(self, slide_level, l):
+    def _l0_from_l(self, slide_level: int, l: float) -> float:
         return self._l0_l_downsamples[slide_level] * l
 
-    def _l_from_z(self, dz_level, z):
+    def _l_from_z(self, dz_level: int, z: int) -> float:
         return self._l_z_downsamples[dz_level] * z
 
-    def _z_from_t(self, t):
+    def _z_from_t(self, t: int) -> int:
         return self._z_t_downsample * t
 
-    def get_tile_coordinates(self, level, address):
+    def get_tile_coordinates(
+        self, level: int, address: tuple[int, int]
+    ) -> tuple[tuple[int, int], int, tuple[int, int]]:
         """Return the OpenSlide.read_region() arguments for the specified tile.
 
         Most users should call get_tile() rather than calling
@@ -256,7 +285,9 @@ class DeepZoomGenerator:
                    tuple."""
         return self._get_tile_info(level, address)[0]
 
-    def get_tile_dimensions(self, level, address):
+    def get_tile_dimensions(
+        self, level: int, address: tuple[int, int]
+    ) -> tuple[int, int]:
         """Return a (pixels_x, pixels_y) tuple for the specified tile.
 
         level:     the Deep Zoom level.
@@ -264,7 +295,7 @@ class DeepZoomGenerator:
                    tuple."""
         return self._get_tile_info(level, address)[1]
 
-    def get_dzi(self, format):
+    def get_dzi(self, format: str) -> str:
         """Return a string containing the XML metadata for the .dzi file.
 
         format:    the format of the individual tiles ('png' or 'jpeg')"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,6 @@ force_sort_within_sections = true
 [tool.mypy]
 python_version = "3.10"
 strict = true
-# temporary, while we bootstrap type checking
-follow_imports = "silent"
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/tests/test_imageslide.py
+++ b/tests/test_imageslide.py
@@ -49,8 +49,9 @@ class TestImageWithoutOpening(unittest.TestCase):
             osr = ImageSlide(img)
             osr.close()
             self.assertRaises(
-                AttributeError, lambda: osr.read_region((0, 0), 0, (100, 100))
+                ValueError, lambda: osr.read_region((0, 0), 0, (100, 100))
             )
+            self.assertRaises(ValueError, lambda: osr.level_dimensions)
             # If an Image is passed to the constructor, ImageSlide.close()
             # shouldn't close it
             self.assertEqual(img.getpixel((0, 0)), 3)
@@ -59,9 +60,8 @@ class TestImageWithoutOpening(unittest.TestCase):
         osr = ImageSlide(file_path('boxes.png'))
         with osr:
             pass
-        self.assertRaises(
-            AttributeError, lambda: osr.read_region((0, 0), 0, (100, 100))
-        )
+        self.assertRaises(ValueError, lambda: osr.read_region((0, 0), 0, (100, 100)))
+        self.assertRaises(ValueError, lambda: osr.level_dimensions)
 
 
 class _SlideTest:


### PR DESCRIPTION
Hey folks,

An attempt to address #157 

I've typed the main interface and the deepzoom file, with ignoring type hints for the harder-to-type lowlevel file.

I think I could get there for lowlevel as well but would this suffice in the meantime?

Would have a few conflicts with https://github.com/openslide/openslide-python/pull/243, is that still active?

I've strict typed against 3.8 as per the mypy settings in pyproject.toml. Opted for mypy as that's the tool I'm familiar wth