### PR TITLE
pyproject: link to release notes from PyPI page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dynamic = ["version"]
 [project.urls]
 Homepage = "https://openslide.org/"
 Documentation = "https://openslide.org/api/python/"
+"Release notes" = "https://github.com/openslide/openslide-python/blob/main/CHANGELOG.md"
 Repository = "https://github.com/openslide/openslide-python"
 
 [tool.setuptools]


### PR DESCRIPTION
Link to [`CHANGELOG.md`](https://github.com/openslide/openslide-python/blob/main/CHANGELOG.md) instead of the [GitHub Releases page](https://github.com/openslide/openslide-python/releases), since it's less noisy.