### PR TITLE
workflows: autodetect latest openslide-bin release

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -151,8 +151,6 @@ jobs:
     name: Windows
     needs: pre-commit
     runs-on: windows-latest
-    env:
-      BIN_RELEASE: 20231011
     defaults:
       run:
         shell: bash
@@ -171,11 +169,17 @@ jobs:
         python -m pip install --upgrade pip
         pip install build flask pytest
     - name: Install OpenSlide
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         mkdir -p c:\\openslide
         cd c:\\openslide
-        zipname=openslide-win64-${BIN_RELEASE}
-        curl -LfO "https://github.com/openslide/openslide-bin/releases/download/v${BIN_RELEASE}/${zipname}.zip"
+        release=$(gh release list -R openslide/openslide-bin -L 1 \
+            --json tagName --exclude-drafts --exclude-pre-releases | \
+            jq -r .[0].tagName | \
+            tr -d v)
+        zipname="openslide-win64-${release}"
+        curl -LfO "https://github.com/openslide/openslide-bin/releases/download/v${release}/${zipname}.zip"
         7z x ${zipname}.zip
         echo "OPENSLIDE_PATH=c:\\openslide\\${zipname}\\bin" >> $GITHUB_ENV
     - name: Build wheel

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -179,7 +179,8 @@ jobs:
             jq -r .[0].tagName | \
             tr -d v)
         zipname="openslide-win64-${release}"
-        curl -LfO "https://github.com/openslide/openslide-bin/releases/download/v${release}/${zipname}.zip"
+        gh release download -R openslide/openslide-bin "v${release}" \
+            --pattern "${zipname}.zip"
         7z x ${zipname}.zip
         echo "OPENSLIDE_PATH=c:\\openslide\\${zipname}\\bin" >> $GITHUB_ENV
     - name: Build wheel


### PR DESCRIPTION
rather than hardcoding a version number.

Also use `gh release download` instead of hardcoding the openslide-bin zip URL template.