### PR TITLE
workflows: switch from `macos-14` to `macos-latest`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
         include:
           - os: ubuntu-latest
@@ -52,10 +52,10 @@ jobs:
           # setup-python's Python 3.9 and 3.10 won't build them.  Use the
           # last upstream patch releases that ship with installers.
           # https://github.com/actions/setup-python/issues/439#issuecomment-1247646682
-          - os: macos-14
+          - os: macos-latest
             python-version: "3.9"
             upstream-python: 3.9.13
-          - os: macos-14
+          - os: macos-latest
             python-version: "3.10"
             upstream-python: 3.10.11
     steps:
@@ -93,7 +93,7 @@ jobs:
           echo OS_TAG=linux >> $GITHUB_ENV
           sudo apt-get install libopenslide0
           ;;
-        macos-14)
+        macos-latest)
           echo OS_TAG=macos >> $GITHUB_ENV
           echo DYLD_LIBRARY_PATH=/opt/homebrew/lib >> $GITHUB_ENV
           brew install openslide


### PR DESCRIPTION
The latter is now an alias for the former.  Switch back so we get future OS updates.