### PR TITLE
Remove unnecessary unpacking

### DIFF
--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -145,7 +145,7 @@ class AbstractSlide:
         """Return a PIL.Image containing an RGB thumbnail of the image.
 
         size:     the maximum size of the thumbnail."""
-        downsample = max(*(dim / thumb for dim, thumb in zip(self.dimensions, size)))
+        downsample = max(dim / thumb for dim, thumb in zip(self.dimensions, size))
         level = self.get_best_level_for_downsample(downsample)
         tile = self.read_region((0, 0), level, self.level_dimensions[level])
         # Apply on solid background


### PR DESCRIPTION
Hi, I am a user who really enjoys and actively utilizes OpenSlide. I would like to express my gratitude to @bgilbert for creating such an excellent open-source project!

## What is this PR?

While using the code, I found a small area where I could contribute, so I created a PR with a one-line change. Since the `max()` function can accept iterable objects such as generators, it seems that there is no need to unpack them using an asterisk `*`.

## Changes

- Refactor code by removing unnecessary unpack operator `*`