### PR TITLE
pre-commit: require PEP 563 type annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,18 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
+
+  - repo: local
+    hooks:
+      - id: annotations
+        name: Require "from __future__ import annotations"
+        language: pygrep
+        types: [python]
+        # exclude config-like files
+        exclude: "^(setup\\.py|doc/conf\\.py|openslide/_version\\.py)$"
+        # Allow files with import statement, or of less than two characters.
+        # One-character files are allowed because that's the best we can do
+        # with paired negative lookbehind and lookahead assertions.  ^ and $
+        # don't work because --multiline causes them to match at newlines.
+        entry: "(?<!.)(?!.)|\nfrom __future__ import annotations"
+        args: [--multiline, --negate]

--- a/doc/jekyll_fix.py
+++ b/doc/jekyll_fix.py
@@ -23,6 +23,8 @@
 # deployed to the website.
 # Rename Sphinx output paths to drop the underscore.
 
+from __future__ import annotations
+
 import os
 
 from sphinx.util import logging

--- a/examples/deepzoom/deepzoom_multiserver.py
+++ b/examples/deepzoom/deepzoom_multiserver.py
@@ -19,6 +19,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from __future__ import annotations
+
 from argparse import ArgumentParser
 import base64
 from collections import OrderedDict

--- a/examples/deepzoom/deepzoom_server.py
+++ b/examples/deepzoom/deepzoom_server.py
@@ -19,6 +19,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from __future__ import annotations
+
 from argparse import ArgumentParser
 import base64
 from io import BytesIO

--- a/examples/deepzoom/deepzoom_tile.py
+++ b/examples/deepzoom/deepzoom_tile.py
@@ -21,6 +21,8 @@
 
 """An example program to generate a Deep Zoom directory tree from a slide."""
 
+from __future__ import annotations
+
 from argparse import ArgumentParser
 import base64
 from io import BytesIO

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -23,6 +23,8 @@
 This package provides Python bindings for the OpenSlide library.
 """
 
+from __future__ import annotations
+
 from collections.abc import Mapping
 from io import BytesIO
 

--- a/openslide/deepzoom.py
+++ b/openslide/deepzoom.py
@@ -23,6 +23,8 @@ This module provides functionality for generating Deep Zoom images from
 OpenSlide objects.
 """
 
+from __future__ import annotations
+
 from io import BytesIO
 import math
 from xml.etree.ElementTree import Element, ElementTree, SubElement

--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -30,6 +30,8 @@ returned by OpenSlide into a non-premultiplied PIL.Image happens here
 rather than in the high-level interface.)
 """
 
+from __future__ import annotations
+
 from ctypes import (
     POINTER,
     byref,

--- a/tests/common.py
+++ b/tests/common.py
@@ -17,6 +17,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from __future__ import annotations
+
 import os
 from pathlib import Path
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,6 +17,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from __future__ import annotations
+
 import ctypes
 import unittest
 
@@ -35,13 +37,17 @@ class TestLibrary(unittest.TestCase):
     def test_lowlevel_available(self):
         '''Ensure all exported functions have an 'available' attribute.'''
         for name in dir(lowlevel):
+            attr = getattr(lowlevel, name)
             # ignore classes and unexported functions
             if name.startswith('_') or name[0].isupper():
+                continue
+            # ignore __future__ imports
+            if getattr(attr, '__module__', None) == '__future__':
                 continue
             # ignore random imports
             if hasattr(ctypes, name) or name in ('count', 'platform'):
                 continue
             self.assertTrue(
-                hasattr(getattr(lowlevel, name), 'available'),
+                hasattr(attr, 'available'),
                 f'"{name}" missing "available" attribute',
             )

--- a/tests/test_deepzoom.py
+++ b/tests/test_deepzoom.py
@@ -17,6 +17,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from __future__ import annotations
+
 import unittest
 
 from common import file_path

--- a/tests/test_imageslide.py
+++ b/tests/test_imageslide.py
@@ -17,6 +17,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from __future__ import annotations
+
 import unittest
 
 from PIL import Image

--- a/tests/test_openslide.py
+++ b/tests/test_openslide.py
@@ -17,6 +17,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from __future__ import annotations
+
 from ctypes import ArgumentError
 import re
 import sys


### PR DESCRIPTION
Require `from __future__ import annotations` in every Python file that isn't a known config file.  Prep for adding type annotations.