### PR TITLE
Add type hints to `_convert` and `lowlevel`; add type-checking infrastructure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,8 +58,8 @@ repos:
     hooks:
       - id: mypy
         name: Check Python types
-        additional_dependencies: [types-setuptools]
-        exclude: "^(doc/.*|openslide/(__init__|deepzoom|lowlevel)\\.py|tests/.*|examples/deepzoom/.*)$"
+        additional_dependencies: [openslide-bin, pillow, types-setuptools]
+        exclude: "^(doc/.*|openslide/(__init__|deepzoom)\\.py|tests/.*|examples/deepzoom/.*)$"
 
   - repo: https://github.com/rstcheck/rstcheck
     rev: v6.2.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,14 @@ repos:
         name: Lint python code with flake8
         additional_dependencies: [flake8-bugbear, Flake8-pyproject]
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        name: Check Python types
+        additional_dependencies: [types-setuptools]
+        exclude: "^(doc/.*|openslide/(__init__|deepzoom|lowlevel)\\.py|tests/.*|examples/deepzoom/.*)$"
+
   - repo: https://github.com/rstcheck/rstcheck
     rev: v6.2.4
     hooks:

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -32,13 +32,17 @@ from PIL import Image, ImageCms
 
 from openslide import lowlevel
 
-# For the benefit of library users
-from openslide._version import __version__  # noqa: F401  module-imported-but-unused
-from openslide.lowlevel import (  # noqa: F401  module-imported-but-unused
-    OpenSlideError,
-    OpenSlideUnsupportedFormatError,
-    OpenSlideVersionError,
+# Re-exports for the benefit of library users
+from openslide._version import (  # noqa: F401  module-imported-but-unused
+    __version__ as __version__,
 )
+from openslide.lowlevel import (
+    OpenSlideUnsupportedFormatError as OpenSlideUnsupportedFormatError,
+)
+from openslide.lowlevel import (  # noqa: F401  module-imported-but-unused
+    OpenSlideVersionError as OpenSlideVersionError,
+)
+from openslide.lowlevel import OpenSlideError as OpenSlideError
 
 __library_version__ = lowlevel.get_version()
 

--- a/openslide/_convert.pyi
+++ b/openslide/_convert.pyi
@@ -1,0 +1,26 @@
+#
+# openslide-python - Python bindings for the OpenSlide library
+#
+# Copyright (c) 2024 Benjamin Gilbert
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License
+# as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+from typing import Protocol
+
+class _Buffer(Protocol):
+    # Python 3.12+ has collections.abc.Buffer
+    def __buffer__(self, flags: int) -> memoryview: ...
+
+def argb2rgba(buf: _Buffer) -> None: ...

--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -265,6 +265,18 @@ def _check_name_list(result, func, args):
     return names
 
 
+class _FunctionUnavailable:
+    '''Standin for a missing optional function.  Fails when called.'''
+
+    def __init__(self, minimum_version):
+        self._minimum_version = minimum_version
+        # allow checking for availability without calling the function
+        self.available = False
+
+    def __call__(self, *_args):
+        raise OpenSlideVersionError(self._minimum_version)
+
+
 # resolve and return an OpenSlide function with the specified properties
 def _func(name, restype, argtypes, errcheck=_check_error, minimum_version=None):
     try:
@@ -272,15 +284,8 @@ def _func(name, restype, argtypes, errcheck=_check_error, minimum_version=None):
     except AttributeError:
         if minimum_version is None:
             raise
-
-        # optional function doesn't exist; fail at runtime
-        def function_unavailable(*_args):
-            raise OpenSlideVersionError(minimum_version)
-
-        # allow checking for availability without calling the function
-        function_unavailable.available = False
-
-        return function_unavailable
+        else:
+            return _FunctionUnavailable(minimum_version)
     func.argtypes = argtypes
     func.restype = restype
     if errcheck is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,12 @@ extend-ignore = ["E203", "E741"]
 profile = "black"
 force_sort_within_sections = true
 
+[tool.mypy]
+python_version = "3.10"
+strict = true
+# temporary, while we bootstrap type checking
+follow_imports = "silent"
+
 [tool.pytest.ini_options]
 minversion = "7.0"
 # don't try to import openslide from the source directory, since it doesn't


### PR DESCRIPTION
Only support type-checking on Python 3.10+, at least for now.

Prep for #260.  I'll rebase that PR after this lands.