### PR TITLE
feat: more granular error messages when looking for shared objects

### DIFF
--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -72,12 +72,14 @@ def _load_library() -> CDLL:
         pass
 
     def try_load(names: list[str]) -> CDLL:
+        error_strings = []
         for name in names:
             try:
                 return cdll.LoadLibrary(name)
-            except OSError:
+            except OSError as err:
+                error_strings.append(f"{name}: {err}")
                 if name == names[-1]:
-                    raise
+                    raise OSError("\n".join(error_strings))
         else:
             raise ValueError('No library names specified')
 


### PR DESCRIPTION
- Had run into a situation where loading libopenslide.so.1 failed because my system had an old version of libglib but the error message shown was libopenslide.so.0 not found.
- This fixes that by giving the error message for each one of the shared objects the code looks for in case it did not find any.