### PR TITLE
examples/deepzoom: enforce `--format` enum in argparse

### DIFF
--- a/examples/deepzoom/deepzoom_multiserver.py
+++ b/examples/deepzoom/deepzoom_multiserver.py
@@ -356,8 +356,8 @@ if __name__ == '__main__':
     parser.add_argument(
         '-f',
         '--format',
-        metavar='{jpeg|png}',
         dest='DEEPZOOM_FORMAT',
+        choices=['jpeg', 'png'],
         help='image format for tiles [jpeg]',
     )
     parser.add_argument(

--- a/examples/deepzoom/deepzoom_server.py
+++ b/examples/deepzoom/deepzoom_server.py
@@ -293,8 +293,8 @@ if __name__ == '__main__':
     parser.add_argument(
         '-f',
         '--format',
-        metavar='{jpeg|png}',
         dest='DEEPZOOM_FORMAT',
+        choices=['jpeg', 'png'],
         help='image format for tiles [jpeg]',
     )
     parser.add_argument(

--- a/examples/deepzoom/deepzoom_tile.py
+++ b/examples/deepzoom/deepzoom_tile.py
@@ -426,9 +426,9 @@ if __name__ == '__main__':
     parser.add_argument(
         '-f',
         '--format',
-        metavar='{jpeg|png}',
         dest='format',
         default='jpeg',
+        choices=['jpeg', 'png'],
         help='image format for tiles [jpeg]',
     )
     parser.add_argument(


### PR DESCRIPTION
Give clearer feedback if the argument is invalid.  For the WSGI programs we need to continue enforcing validity outside of argparse, since the value may be set by other means.