### PR TITLE
Include all `LoadLibrary()` failures in exception chain

### DIFF
--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -293,8 +293,8 @@ class OpenSlide(AbstractSlide):
         cache: an OpenSlideCache object."""
         try:
             llcache = cache._openslide_cache
-        except AttributeError:
-            raise TypeError('Not a cache object')
+        except AttributeError as exc:
+            raise TypeError('Not a cache object') from exc
         lowlevel.set_cache(self._osr, llcache)
 
 

--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -72,14 +72,16 @@ def _load_library() -> CDLL:
         pass
 
     def try_load(names: list[str]) -> CDLL:
-        for name in names:
-            try:
-                return cdll.LoadLibrary(name)
-            except OSError:
-                if name == names[-1]:
-                    raise
-        else:
-            raise ValueError('No library names specified')
+        try:
+            return cdll.LoadLibrary(names[0])
+        except OSError:
+            remaining = names[1:]
+            if remaining:
+                # handle recursively so implicit exception chaining captures
+                # all the failures
+                return try_load(remaining)
+            else:
+                raise
 
     if platform.system() == 'Windows':
         try:

--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -84,18 +84,18 @@ def _load_library() -> CDLL:
     if platform.system() == 'Windows':
         try:
             return try_load(['libopenslide-1.dll', 'libopenslide-0.dll'])
-        except FileNotFoundError:
+        except FileNotFoundError as exc:
             raise ModuleNotFoundError(
                 "Couldn't locate OpenSlide DLL. "
                 "Try `pip install openslide-bin`, "
                 "or if you're using an OpenSlide binary package, "
                 "ensure you've called os.add_dll_directory(). "
                 "https://openslide.org/api/python/#installing"
-            )
+            ) from exc
     elif platform.system() == 'Darwin':
         try:
             return try_load(['libopenslide.1.dylib', 'libopenslide.0.dylib'])
-        except OSError:
+        except OSError as exc:
             # MacPorts doesn't add itself to the dyld search path, but
             # does add itself to the find_library() search path
             # (DEFAULT_LIBRARY_FALLBACK in ctypes.macholib.dyld).
@@ -107,17 +107,17 @@ def _load_library() -> CDLL:
                     "Couldn't locate OpenSlide dylib. "
                     "Try `pip install openslide-bin`. "
                     "https://openslide.org/api/python/#installing"
-                )
+                ) from exc
             return cdll.LoadLibrary(lib)
     else:
         try:
             return try_load(['libopenslide.so.1', 'libopenslide.so.0'])
-        except OSError:
+        except OSError as exc:
             raise ModuleNotFoundError(
                 "Couldn't locate OpenSlide shared library. "
                 "Try `pip install openslide-bin`. "
                 "https://openslide.org/api/python/#installing"
-            )
+            ) from exc
 
 
 _lib = _load_library()


### PR DESCRIPTION
If `libopenslide.so.1` fails to load, we want to report that exception too, not just the fact that `libopenslide.so.0` doesn't exist.  Make `try_load()` recursive rather than iterative, allowing Python's exception chaining to handle this automatically.  Reported by @govinda-kamath; thanks!

Also use explicit exception chaining during any conversion of exception types.  This changes Python's exception chain reporting to make it clear that the new exception was not an unrelated failure while handling the original one, but rather the direct cause of it.