### PR TITLE
examples/deepzoom: parallelize `deepzoom_tile` to available CPUs

### DIFF
--- a/examples/deepzoom/deepzoom_multiserver.py
+++ b/examples/deepzoom/deepzoom_multiserver.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 if os.name == 'nt':
     _dll_path = os.getenv('OPENSLIDE_PATH')
     if _dll_path is not None:
-        with os.add_dll_directory(_dll_path):  # type: ignore[attr-defined]
+        with os.add_dll_directory(_dll_path):  # type: ignore[attr-defined,unused-ignore]  # noqa: E501
             import openslide
     else:
         import openslide

--- a/examples/deepzoom/deepzoom_server.py
+++ b/examples/deepzoom/deepzoom_server.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 if os.name == 'nt':
     _dll_path = os.getenv('OPENSLIDE_PATH')
     if _dll_path is not None:
-        with os.add_dll_directory(_dll_path):  # type: ignore[attr-defined]
+        with os.add_dll_directory(_dll_path):  # type: ignore[attr-defined,unused-ignore]  # noqa: E501
             import openslide
     else:
         import openslide

--- a/examples/deepzoom/deepzoom_tile.py
+++ b/examples/deepzoom/deepzoom_tile.py
@@ -382,6 +382,19 @@ class DeepZoomStaticTiler:
 
 
 if __name__ == '__main__':
+    try:
+        # Python 3.13+
+        available_cpus = os.process_cpu_count()  # type: ignore[attr-defined]
+    except AttributeError:
+        try:
+            # Linux
+            available_cpus = len(
+                os.sched_getaffinity(0)  # type: ignore[attr-defined,unused-ignore]
+            )
+        except AttributeError:
+            # default
+            available_cpus = 4
+
     parser = ArgumentParser(usage='%(prog)s [options] <SLIDE>')
     parser.add_argument(
         '-B',
@@ -433,8 +446,8 @@ if __name__ == '__main__':
         metavar='COUNT',
         dest='workers',
         type=int,
-        default=4,
-        help='number of worker processes to start [4]',
+        default=available_cpus,
+        help=f'number of worker processes to start [{available_cpus}]',
     )
     parser.add_argument(
         '-o',

--- a/examples/deepzoom/deepzoom_tile.py
+++ b/examples/deepzoom/deepzoom_tile.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 if os.name == 'nt':
     _dll_path = os.getenv('OPENSLIDE_PATH')
     if _dll_path is not None:
-        with os.add_dll_directory(_dll_path):  # type: ignore[attr-defined]
+        with os.add_dll_directory(_dll_path):  # type: ignore[attr-defined,unused-ignore]  # noqa: E501
             import openslide
     else:
         import openslide

--- a/tests/common.py
+++ b/tests/common.py
@@ -30,7 +30,7 @@ if os.name == 'nt':
     # environment.
     _dll_path = os.getenv('OPENSLIDE_PATH')
     if _dll_path is not None:
-        with os.add_dll_directory(_dll_path):  # type: ignore[attr-defined]
+        with os.add_dll_directory(_dll_path):  # type: ignore[attr-defined,unused-ignore]  # noqa: E501
             import openslide  # noqa: F401  module-imported-but-unused
 
 


### PR DESCRIPTION
On Python 3.13+, and on all Python versions on Linux, set the default job count to the number of available CPUs.  Otherwise, default to 4 jobs as before.

Also: if OpenSlide Python is type-checked on Windows, `os.add_dll_directory()` will exist and mypy will complain.  Add an extra ignore to fix this.  Mypy understands conditionalizing on `sys.platform` but not on `os.name`, and we want the latter because it exactly corresponds to whether the function exists.
