### PR TITLE
setuptools 69.3+ normalizes sdist name to `openslide_python`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -283,14 +283,14 @@ jobs:
       run: |
         version=$(echo "${{ github.ref_name }}" | sed "s/^v//")
         # recompress tarball with xz
-        gunzip -k "${{ needs.pre-commit.outputs.dist-base }}/openslide-python-${version}.tar.gz"
-        tar xf "${{ needs.pre-commit.outputs.dist-base }}/openslide-python-${version}.tar"
-        xz -9 "${{ needs.pre-commit.outputs.dist-base }}/openslide-python-${version}.tar"
+        gunzip -k "${{ needs.pre-commit.outputs.dist-base }}/openslide_python-${version}.tar.gz"
+        tar xf "${{ needs.pre-commit.outputs.dist-base }}/openslide_python-${version}.tar"
+        xz -9 "${{ needs.pre-commit.outputs.dist-base }}/openslide_python-${version}.tar"
         # extract changelog
         awk -e '/^## / && ok {exit}' \
             -e '/^## / {ok=1; next}' \
             -e 'ok {print}' \
-            "openslide-python-$version/CHANGELOG.md" > changes
+            "openslide_python-$version/CHANGELOG.md" > changes
         gh release create --latest --verify-tag \
             --repo "${{ github.repository }}" \
             --title "OpenSlide Python $version" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changes
 
 * Drop wheel for 32-bit Windows
+* Rename source distribution to `openslide_python` per [PEP 625][]
 * Require `AbstractSlide` subclasses to implement all abstract methods
 * Provide default `AbstractSlide.set_cache()` implementation
 * Switch to [PEP 621][] project metadata
@@ -29,6 +30,7 @@
 * docs: Fix types of properties that return tuples of items
 
 [installed from PyPI]: https://pypi.org/project/openslide-bin/
+[PEP 625]: https://peps.python.org/pep-0625/
 [PEP 621]: https://peps.python.org/pep-0621/
 [Python filesystem encoding]: https://docs.python.org/3/glossary.html#term-filesystem-encoding-and-error-handler
 


### PR DESCRIPTION
Current versions of setuptools normalize the filename of the source tarball and of its toplevel directory to `openslide_python-*` per [PEP 625](https://peps.python.org/pep-0625/); see https://github.com/pypa/setuptools/issues/3593. This is an intentional ecosystem-wide change, so adapt to it rather than trying to undo it.