### PR TITLE
templates: release checklist updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -6,11 +6,12 @@
   - [ ] Once the build finishes, approve deployment to PyPI
   - [ ] Download the docs artifact
 - [ ] Verify that the workflow created a [PyPI release](https://pypi.org/p/openslide-python) with a description, source tarball, and wheels
-- [ ] Verify that the workflow created a [GitHub release](https://github.com/openslide/openslide-python/releases) with release notes, a source tarball, and wheels
+- [ ] Verify that the workflow created a [GitHub release](https://github.com/openslide/openslide-python/releases) with release notes, source tarballs, and wheels
 - [ ] `cd` into website checkout; `rm -r api/python && unzip /path/to/downloaded/openslide-python-docs.zip && mv openslide-python-docs-* api/python`
 - [ ] Update website: `_data/releases.yaml`, `_includes/news.md`
+- [ ] Start a [CI build](https://github.com/openslide/openslide.github.io/actions/workflows/retile.yml) of the demo site
 - [ ] Update Ubuntu PPA
-- [ ] Update Fedora and EPEL packages
+- [ ] Update Fedora and possibly EPEL packages
 - [ ] Check that [Copr package](https://copr.fedorainfracloud.org/coprs/g/openslide/openslide/builds/) built successfully
 - [ ] Send mail to -announce and -users
 - [ ] Post to [forum.image.sc](https://forum.image.sc/c/announcements/10)


### PR DESCRIPTION
The GitHub release will have multiple source tarballs.  We should retile the demo site after a release because the OpenSlide Python version is listed on the site.  EPEL packaging might skip some OpenSlide Python releases due to the [EPEL update policy](https://docs.fedoraproject.org/en-US/epel/epel-policy/#_digest).