### PR TITLE
Fix configuration of package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.md
+global-include py.typed *.pyi
 recursive-include doc *.py *.rst
 recursive-include examples *.html *.js *.png *.py
 recursive-include tests *.dcm *.png *.py *.svs *.tiff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,14 @@ Documentation = "https://openslide.org/api/python/"
 Repository = "https://github.com/openslide/openslide-python"
 
 [tool.setuptools]
+include-package-data = false
 packages = ["openslide"]
 
 [tool.setuptools.dynamic]
 version = {attr = "openslide._version.__version__"}
+
+[tool.setuptools.package-data]
+openslide = ["py.typed", "*.pyi"]
 
 [tool.black]
 skip-string-normalization = true

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,4 @@ setup(
         # tag wheel for Limited API
         'bdist_wheel': {'py_limited_api': 'cp311'} if _abi3 else {},
     },
-    package_data={
-        'openslide': ['py.typed'],
-    },
 )


### PR DESCRIPTION
When setuptools 61+ is configured via `pyproject.toml`, it defaults to `include-package-data = true`, rather than the historical default of `false`. We don't want wheels to include random files from the package directory, in particular `_convert.c`.  Disable `include-package-data`.

In addition, we were inadvertently relying on setuptools 69+ experimental functionality to include `.pyi` and `py.typed` files in the sdist and `.pyi` files in wheels.  Explicitly configure this.

Move `py.typed` `package-data` declaration from `setup.py` to `pyproject.toml`.