### PR TITLE
Fix `setup.py install` with old setuptools

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -231,6 +231,25 @@ jobs:
         path: artifacts/whl
         compression-level: 0
 
+  setuptools:
+    name: Setuptools install
+    needs: pre-commit
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libopenslide0 python3-pil
+        pip install pytest
+    - name: Install OpenSlide Python
+      run: sudo python setup.py install
+    - name: Run tests
+      run: pytest -v
+    - name: Tile slide
+      run: python examples/deepzoom/deepzoom_tile.py --viewer -o tiled tests/fixtures/small.svs
+
   docs:
     name: Docs
     needs: pre-commit

--- a/examples/deepzoom/deepzoom_tile.py
+++ b/examples/deepzoom/deepzoom_tile.py
@@ -335,7 +335,7 @@ class DeepZoomStaticTiler:
             # We're not running from a module (e.g. "python deepzoom_tile.py")
             # so PackageLoader('__main__') doesn't work in jinja2 3.x.
             # Load templates directly from the filesystem.
-            loader = jinja2.FileSystemLoader(Path(__file__).parent / 'templates')
+            loader = jinja2.FileSystemLoader([Path(__file__).parent / 'templates'])
         env = jinja2.Environment(loader=loader, autoescape=True)
         template = env.get_template('slide-multipane.html')
         associated_urls = {n: self._url_for(n) for n in self._slide.associated_images}

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
+from pathlib import Path
 import sys
 
 from setuptools import Extension, setup
+
+# Load version string
+with open(Path(__file__).parent / 'openslide/_version.py') as _fh:
+    exec(_fh.read())  # instantiates __version__
 
 # use the Limited API on Python 3.11+; build release-specific wheels on
 # older Python
@@ -21,4 +26,18 @@ setup(
         # tag wheel for Limited API
         'bdist_wheel': {'py_limited_api': 'cp311'} if _abi3 else {},
     },
+    #
+    # setuptools < 61 compatibility for distro packages building from source
+    name='openslide-python',
+    version=__version__,  # type: ignore[name-defined]  # noqa: F821
+    install_requires=[
+        'Pillow',
+    ],
+    packages=[
+        'openslide',
+    ],
+    package_data={
+        'openslide': ['py.typed', '*.pyi'],
+    },
+    zip_safe=False,
 )


### PR DESCRIPTION
We still need to support building distro packages with older setuptools that doesn't understand PEP 621.  Re-add enough `setup.py` configuration (duplicating `pyproject.toml`) to make older setuptools happy.

Also work around a `FileSystemLoader` bug in Jinja2 < 2.11.0.