### PR TITLE
workflows: omit `*.publish.attestation` files from release artifacts

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -310,9 +310,11 @@ jobs:
             -e '/^## / {ok=1; next}' \
             -e 'ok {print}' \
             "openslide_python-$version/CHANGELOG.md" > changes
+        # create release; upload artifacts but not *.publish.attestation
+        # files created by gh-action-pypi-publish
         gh release create --latest --verify-tag \
             --repo "${{ github.repository }}" \
             --title "OpenSlide Python $version" \
             --notes-file changes \
             "${{ github.ref_name }}" \
-            "${{ needs.pre-commit.outputs.dist-base }}/"*
+            "${{ needs.pre-commit.outputs.dist-base }}/"*.{tar.gz,tar.xz,whl}


### PR DESCRIPTION
`gh-action-pypi-publish` now writes attestation files to the artifact directory that should not be uploaded to the GitHub release.  Add explicit wildcards for the file extensions we do want to upload.