### PR TITLE
workflows: switch ARM jobs to publicly-available runners

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-aarch64, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
         openslide: [system, wheel]
         include:
@@ -96,7 +96,7 @@ jobs:
           echo OS_ARCH_TAG=linux-x86_64 >> $GITHUB_ENV
           sudo apt-get install libopenslide0
           ;;
-        ubuntu-24.04-aarch64)
+        ubuntu-24.04-arm)
           echo OS_ARCH_TAG=linux-aarch64 >> $GITHUB_ENV
           sudo apt-get install libopenslide0
           ;;


### PR DESCRIPTION
[Drop](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) the paid runners.