### PR TITLE
workflows: switch setuptools job to Ubuntu 22.04 container

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -235,7 +235,7 @@ jobs:
     name: Setuptools install
     needs: pre-commit
     runs-on: ubuntu-latest
-    container: ubuntu:20.04
+    container: ubuntu:22.04
     steps:
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Ubuntu 20.04 is exiting standard security support at the end of May. Switch to 22.04, which still has an old enough setuptools.  Stick with the container, rather than using GitHub's `ubuntu-22.04` runner image, for better control over the included software versions.