### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
         openslide: [system, wheel]
         include:
           - os: ubuntu-latest
@@ -158,7 +158,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
         openslide: [zip, wheel]
     steps:
     - name: Check out repo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: pyupgrade
         name: Modernize python code
-        args: ["--py38-plus"]
+        args: ["--py39-plus"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ OpenSlide can read virtual slides in several formats:
 
 ## Requirements
 
-* Python ≥ 3.8
+* Python ≥ 3.9
 * OpenSlide ≥ 3.4.0
 * Pillow
 

--- a/examples/deepzoom/deepzoom_server.py
+++ b/examples/deepzoom/deepzoom_server.py
@@ -23,12 +23,12 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 import base64
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from io import BytesIO
 import os
 from pathlib import Path
 import re
-from typing import TYPE_CHECKING, Any, Literal, Mapping
+from typing import TYPE_CHECKING, Any, Literal
 from unicodedata import normalize
 import zlib
 

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -26,9 +26,10 @@ This package provides Python bindings for the OpenSlide library.
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from collections.abc import Iterator, Mapping
 from io import BytesIO
 from types import TracebackType
-from typing import Iterator, Literal, Mapping, TypeVar
+from typing import Literal, TypeVar
 
 from PIL import Image, ImageCms
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -27,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Typing :: Typed",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 dependencies = ["Pillow"]
 dynamic = ["version"]
 
@@ -49,7 +48,7 @@ openslide = ["py.typed", "*.pyi"]
 
 [tool.black]
 skip-string-normalization = true
-target-version = ["py38", "py39", "py310", "py311", "py312", "py313"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 [tool.codespell]


### PR DESCRIPTION
It's EOL.  Ubuntu 20.04 is the last officially-supported distro that uses it, and Ubuntu 20.04 will exit standard security maintenance on May 31.