### PR TITLE
workflows: expect macOS universal binaries from setup-python on 3.{8,9,10}

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -50,16 +50,6 @@ jobs:
             python-version: "3.13"
             openslide: system
             sdist: sdist
-          # Python 3.8 is too old to support universal binaries, and
-          # setup-python's Python 3.9 and 3.10 won't build them.  Use the
-          # last upstream patch releases that ship with installers.
-          # https://github.com/actions/setup-python/issues/439#issuecomment-1247646682
-          - os: macos-latest
-            python-version: "3.9"
-            upstream-python: 3.9.13
-          - os: macos-latest
-            python-version: "3.10"
-            upstream-python: 3.10.11
     steps:
     - name: Check out repo
       uses: actions/checkout@v4
@@ -122,7 +112,7 @@ jobs:
             auditwheel repair --only-plat -w dist old/*whl
             ;;
         macos-*)
-            if [ "${{ matrix.python-version }}" != 3.8 -a ! -e dist/*universal2* ]; then
+            if [ ! -e dist/*universal2* ]; then
                 echo "Wheel is not universal:"
                 ls dist
                 exit 1


### PR DESCRIPTION
It appears setup-python's Python 3.8, 3.9, and 3.10 macOS builds are now capable of producing universal binaries.  Stop using the upstream Python 3.9 and 3.10 builds and remove the test exception for 3.8.

The change seems to have happened before we released any macOS wheels, so this won't affect the 3.8 release artifacts.