### PR TITLE
Switch to PEP 639 license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ maintainers = [
 ]
 description = "Python interface to OpenSlide"
 readme = "README.md"
-license = {text = "GNU Lesser General Public License, version 2.1"}
+license = "LGPL-2.1-only AND BSD-3-Clause AND MIT AND LicenseRef-Public-Domain"
+license-files = ["COPYING.LESSER", "**/LICENSE.*"]
 keywords = ["OpenSlide", "whole-slide image", "virtual slide", "library"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Healthcare Industry",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
@@ -87,5 +87,5 @@ pythonpath = "tests"
 ignore_messages = "(Hyperlink target \".*\" is not referenced\\.$)"
 
 [build-system]
-requires = ["setuptools >= 61.0.0"]
+requires = ["setuptools >= 77.0.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Conform with [PEP 639](https://peps.python.org/pep-0639/) by adding links to our license files, using a SPDX license expression to declare our licenses, and dropping the deprecated license Trove classifier.

The new syntax for `project.license` requires setuptools &ge; 77, so this change breaks compatibility with setuptools 61-76.  Users installing from source will be unaffected because the build frontend automatically updates setuptools if required, but Linux distro packaging disallows such updates, so **this change breaks package builds for many current distro versions, including all stable versions of Debian, Fedora, and Ubuntu** as well as Debian testing.

setuptools' deprecation warning claims that the old syntax will be removed on 2026-Feb-18.  If setuptools sticks to this plan, they will cause ecosystem-wide packaging disruption.  I intend to maintain the status quo as long as possible in the hope that PyPA opts to extend the deprecation period.  If they do not, and setuptools drops support for the old syntax (and does not reinstate it within a few weeks), we'll probably need to drop the license fields for a few years until distros with setuptools &lt; 77 reach EOL.