### PR TITLE
pyproject: add dependency group for test deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ Documentation = "https://openslide.org/api/python/"
 "Release notes" = "https://github.com/openslide/openslide-python/blob/main/CHANGELOG.md"
 Repository = "https://github.com/openslide/openslide-python"
 
+[dependency-groups]
+test = ["pytest >= 7"]
+
 [tool.setuptools]
 include-package-data = false
 packages = ["openslide"]


### PR DESCRIPTION
Add a [PEP 735](https://peps.python.org/pep-0735/) dependency group that installs a supported version of pytest.  This allows downstream build systems (e.g. Fedora) to autodetect test dependencies.  pip 25.1 allows installing these dependencies with `pip install --group test`.