### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         openslide: [system, wheel]
         include:
           - os: ubuntu-latest
@@ -165,7 +165,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         openslide: [zip, wheel]
     steps:
     - name: Check out repo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: pyupgrade
         name: Modernize python code
-        args: ["--py39-plus"]
+        args: ["--py310-plus"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 7.0.0

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ OpenSlide can read virtual slides in several formats:
 
 ## Requirements
 
-* Python ≥ 3.9
+* Python ≥ 3.10
 * OpenSlide ≥ 3.4.0
 * Pillow
 

--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -31,6 +31,7 @@ rather than in the high-level interface.)
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from ctypes import (
     CDLL,
     POINTER,
@@ -49,7 +50,7 @@ from ctypes import (
 from itertools import count
 import os
 import platform
-from typing import TYPE_CHECKING, Any, Callable, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast
 
 from PIL import Image
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -27,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Typing :: Typed",
 ]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dependencies = ["Pillow"]
 dynamic = ["version"]
 
@@ -52,7 +51,7 @@ openslide = ["py.typed", "*.pyi"]
 
 [tool.black]
 skip-string-normalization = true
-target-version = ["py39", "py310", "py311", "py312", "py313", "py314"]
+target-version = ["py310", "py311", "py312", "py313", "py314"]
 
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 [tool.codespell]


### PR DESCRIPTION
It's EOL upstream.  This loses us Debian 11 (oldoldstable) and the default Python on EL 9.