### PR TITLE
Support free-threaded Python

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
         openslide: [system, wheel]
         include:
           - os: ubuntu-latest
@@ -132,8 +132,8 @@ jobs:
         mkdir -p "artifacts/whl/${{ needs.pre-commit.outputs.dist-base }}"
         mv dist/* "artifacts/whl/${{ needs.pre-commit.outputs.dist-base }}"
         # from system builds, save version-specific wheels and oldest abi3 wheel
-        python -c 'import sys
-        if sys.version_info < (3, 12) and "${{ matrix.openslide }}" == "system":
+        python -c 'import sys, sysconfig
+        if "${{ matrix.openslide }}" == "system" and (sys.version_info < (3, 12) or sysconfig.get_config_var("Py_GIL_DISABLED")):
             print("archive_wheel=1")' >> $GITHUB_ENV
     - name: Install
       run: pip install artifacts/whl/${{ needs.pre-commit.outputs.dist-base }}/*.whl
@@ -165,7 +165,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
         openslide: [zip, wheel]
     steps:
     - name: Check out repo
@@ -203,8 +203,8 @@ jobs:
         mkdir -p "artifacts/whl/${{ needs.pre-commit.outputs.dist-base }}"
         mv dist/*.whl "artifacts/whl/${{ needs.pre-commit.outputs.dist-base }}"
         # from zip builds, save version-specific wheels and oldest abi3 wheel
-        python -c 'import sys
-        if sys.version_info < (3, 12) and "${{ matrix.openslide }}" == "zip":
+        python -c 'import sys, sysconfig
+        if "${{ matrix.openslide }}" == "zip" and (sys.version_info < (3, 12) or sysconfig.get_config_var("Py_GIL_DISABLED")):
             print("archive_wheel=1")' >> $GITHUB_ENV
     - name: Install
       run: pip install artifacts/whl/${{ needs.pre-commit.outputs.dist-base }}/*.whl

--- a/openslide/_convert.c
+++ b/openslide/_convert.c
@@ -103,6 +103,9 @@ static PyMethodDef _convert_methods[] = {
 };
 
 static PyModuleDef_Slot _convert_slots[] = {
+#if PY_VERSION_HEX >= 0x030D0000 && !defined(Py_LIMITED_API)
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
     {0, NULL}
 };
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading :: 2 - Beta",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Typing :: Typed",
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import sys
+import sysconfig
 
 from setuptools import Extension, setup
 
@@ -7,9 +8,9 @@ from setuptools import Extension, setup
 with open(Path(__file__).parent / 'openslide/_version.py') as _fh:
     exec(_fh.read())  # instantiates __version__
 
-# use the Limited API on Python 3.11+; build release-specific wheels on
-# older Python
-_abi3 = sys.version_info >= (3, 11)
+# use the Limited API on Python 3.11+ on GIL builds; build release-specific
+# wheels on older or free-threaded Python
+_abi3 = sys.version_info >= (3, 11) and not sysconfig.get_config_var('Py_GIL_DISABLED')
 
 setup(
     ext_modules=[


### PR DESCRIPTION
Enable free threading in `_convert`, which doesn't have any shared state that needs locking.  The thread safety of the rest of OpenSlide Python should be unaffected by free threading.

Build version-specific wheels on free-threaded Python, since the Limited API isn't available there yet; otherwise continue to build for the Limited API.