### PR TITLE
workflows: drop `awk -e` from release job

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -305,9 +305,7 @@ jobs:
         tar xf "${{ needs.pre-commit.outputs.dist-base }}/openslide_python-${version}.tar"
         xz -9 "${{ needs.pre-commit.outputs.dist-base }}/openslide_python-${version}.tar"
         # extract changelog
-        awk -e '/^## / && ok {exit}' \
-            -e '/^## / {ok=1; next}' \
-            -e 'ok {print}' \
+        awk '/^## / && ok {exit} /^## / {ok=1; next} ok {print}' \
             "openslide_python-$version/CHANGELOG.md" > changes
         # create release; upload artifacts but not *.publish.attestation
         # files created by gh-action-pypi-publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Notable Changes in OpenSlide Python
 
-## Version 1.4.4, 2026-06-07
+## Version 1.4.5, 2026-06-07
 
 ### Changes
 

--- a/openslide/_version.py
+++ b/openslide/_version.py
@@ -21,4 +21,4 @@
 This module is an implementation detail.  The package version should be
 obtained from openslide.__version__."""
 
-__version__ = '1.4.4'
+__version__ = '1.4.5'


### PR DESCRIPTION
ubuntu-slim has mawk, which doesn't support `-e`.