### PR TITLE
workflows: switch release job back to ubuntu-latest

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -279,7 +279,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/openslide-python
     needs: [pre-commit, tests, windows]
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     concurrency: release-${{ github.ref }}
     permissions:
       contents: write
@@ -305,7 +305,9 @@ jobs:
         tar xf "${{ needs.pre-commit.outputs.dist-base }}/openslide_python-${version}.tar"
         xz -9 "${{ needs.pre-commit.outputs.dist-base }}/openslide_python-${version}.tar"
         # extract changelog
-        awk '/^## / && ok {exit} /^## / {ok=1; next} ok {print}' \
+        awk -e '/^## / && ok {exit}' \
+            -e '/^## / {ok=1; next}' \
+            -e 'ok {print}' \
             "openslide_python-$version/CHANGELOG.md" > changes
         # create release; upload artifacts but not *.publish.attestation
         # files created by gh-action-pypi-publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Notable Changes in OpenSlide Python
 
-## Version 1.4.5, 2026-06-07
+## Version 1.4.6, 2026-06-07
 
 ### Changes
 

--- a/openslide/_version.py
+++ b/openslide/_version.py
@@ -21,4 +21,4 @@
 This module is an implementation detail.  The package version should be
 obtained from openslide.__version__."""
 
-__version__ = '1.4.5'
+__version__ = '1.4.6'


### PR DESCRIPTION
The PyPI release step needs Docker.