### PR TITLE
docs: drop `.tif` file extension for Aperio

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ closest to a desired zoom level.
 
 OpenSlide can read virtual slides in several formats:
 
-* [Aperio][] (`.svs`, `.tif`)
+* [Aperio][] (`.svs`)
 * [ARGOS][] (`.avs`)
 * [DICOM][] (`.dcm`)
 * [Hamamatsu][] (`.ndpi`, `.vms`, `.vmu`)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,7 +15,7 @@ closest to a desired zoom level.
 
 OpenSlide can read virtual slides in several formats:
 
-* Aperio_ (``.svs``, ``.tif``)
+* Aperio_ (``.svs``)
 * ARGOS_ (``.avs``)
 * DICOM_ (``.dcm``)
 * Hamamatsu_ (``.ndpi``, ``.vms``, ``.vmu``)


### PR DESCRIPTION
I've never seen this used.