### PR TITLE
pre-commit: update Ruff

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -85,6 +85,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install auditwheel build jinja2 pytest
+        if [ "${{ matrix.python-version }}" = 3.13t ]; then
+            # newer versions drop 3.13t wheels
+            pip install pillow==12.2.0
+        fi
     - name: Install OpenSlide (system)
       if: matrix.openslide == 'system'
       run: |
@@ -178,6 +182,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build flask pytest
+        if [ "${{ matrix.python-version }}" = 3.13t ]; then
+            # newer versions drop 3.13t wheels
+            pip install pillow==12.2.0
+        fi
     - name: Install OpenSlide (zip)
       if: matrix.openslide == 'zip'
       env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.16.1
     hooks:
       - id: ruff-check
         types_or: [python, pyi, pyproject]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,7 +51,7 @@ copyright = '2010-2024 Carnegie Mellon University and others'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-import _version  # noqa: E402  module-level-import-not-at-top-of-file
+import _version
 
 # The short X.Y version.
 version = _version.__version__

--- a/openslide/__init__.py
+++ b/openslide/__init__.py
@@ -164,7 +164,6 @@ class AbstractSlide(metaclass=ABCMeta):
         This class does not support caching, so this method does nothing.
 
         cache: an OpenSlideCache object."""
-        pass
 
     def get_thumbnail(self, size: tuple[int, int]) -> Image.Image:
         """Return a PIL.Image containing an RGB thumbnail of the image.

--- a/openslide/lowlevel.py
+++ b/openslide/lowlevel.py
@@ -310,16 +310,16 @@ class _FunctionUnavailable:
 
 
 _P = ParamSpec('_P')
-_T = TypeVar('_T', covariant=True)
+_T_co = TypeVar('_T_co', covariant=True)
 
 
-class _Func(Protocol[_P, _T]):
+class _Func(Protocol[_P, _T_co]):
     available: bool
 
-    def __call__(self, *args: _P.args) -> _T: ...  # type: ignore[valid-type]
+    def __call__(self, *args: _P.args) -> _T_co: ...  # type: ignore[valid-type]
 
 
-class _CTypesFunc(_Func[_P, _T]):
+class _CTypesFunc(_Func[_P, _T_co]):
     restype: type | None
     argtypes: list[type]
     errcheck: _ErrCheck
@@ -337,9 +337,9 @@ def _func(
     argtypes: list[type],
     errcheck: _ErrCheck = _check_error,
     minimum_version: str | None = None,
-) -> _Func[_P, _T]:
+) -> _Func[_P, _T_co]:
     try:
-        func: _CTypesFunc[_P, _T] = getattr(_lib, name)
+        func: _CTypesFunc[_P, _T_co] = getattr(_lib, name)
     except AttributeError:
         if minimum_version is None:
             raise
@@ -355,9 +355,9 @@ def _func(
 
 def _wraps_funcs(
     wrapped: list[_Func[..., Any]],
-) -> Callable[[Callable[_P, _T]], _Func[_P, _T]]:
-    def decorator(fn: Callable[_P, _T]) -> _Func[_P, _T]:
-        f = cast('_Func[_P, _T]', fn)
+) -> Callable[[Callable[_P, _T_co]], _Func[_P, _T_co]]:
+    def decorator(fn: Callable[_P, _T_co]) -> _Func[_P, _T_co]:
+        f = cast('_Func[_P, _T_co]', fn)
         f.available = True
         for w in wrapped:
             f.available = f.available and w.available

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ quote-style = "single"
 extend-select = ["B", "C4", "FLY", "I", "RUF", "UP"]
 # ambiguous-variable-name
 ignore = ["E741"]
+typing-extensions = false
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import Extension, setup
 
 # Load version string
 with open(Path(__file__).parent / 'openslide/_version.py') as _fh:
-    exec(_fh.read())  # instantiates __version__
+    exec(_fh.read())  # instantiates __version__  # noqa: S102
 
 # use the Limited API on Python 3.11+ on GIL builds; build release-specific
 # wheels on older or free-threaded Python

--- a/tests/test_imageslide.py
+++ b/tests/test_imageslide.py
@@ -39,10 +39,9 @@ class TestImageWithoutOpening(unittest.TestCase):
 
     def test_open_image(self) -> None:
         # passing PIL.Image to ImageSlide
-        with Image.open(file_path('boxes.png')) as img:
-            with ImageSlide(img) as osr:
-                self.assertEqual(osr.dimensions, (300, 250))
-                self.assertEqual(repr(osr), f'ImageSlide({img!r})')
+        with Image.open(file_path('boxes.png')) as img, ImageSlide(img) as osr:
+            self.assertEqual(osr.dimensions, (300, 250))
+            self.assertEqual(repr(osr), f'ImageSlide({img!r})')
 
     @unittest.skipUnless(
         sys.getfilesystemencoding() == 'utf-8',


### PR DESCRIPTION
Disable automatic upgrade to newer typing features that would require a `typing_extensions` dependency for backward compatibility.